### PR TITLE
Don't require `missing/true/falseValues` to be a string

### DIFF
--- a/profiles/dictionary/schema.yaml
+++ b/profiles/dictionary/schema.yaml
@@ -190,19 +190,13 @@ tableSchemaForeignKey:
 tableSchemaTrueValues:
   type: array
   minItems: 1
-  items:
-    type: string
   default: ["true", "True", "TRUE", "1"]
 tableSchemaFalseValues:
   type: array
   minItems: 1
-  items:
-    type: string
   default: ["false", "False", "FALSE", "0"]
 tableSchemaMissingValues:
   type: array
-  items:
-    type: string
   default:
     - ""
   description: Values that when encountered in the source, should be considered


### PR DESCRIPTION
- related to https://github.com/frictionlessdata/specs/issues/621

---

As it's outlined in the mentioned issue the source data is not limited to only strings. Moreover, it's not only actual to `true/falseValues` but for `missingValues` as well.