### PR TITLE
Support `groupChar` for `integer` field type

### DIFF
--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -204,7 +204,7 @@ This lexical formatting `MAY` be modified using these additional properties:
 - **decimalChar**: A string whose value is used to represent a decimal point
   within the number. The default value is ".".
 - **groupChar**: A string whose value is used to group digits within the
-  number. The default value is null. A common value is "," e.g. "100,000".
+  number. This property does not have a default value. A common value is "," e.g. "100,000".
 - **bareNumber**: a boolean field with a default of `true`. If `true` the physical contents of this field `MUST` follow the formatting constraints already set out. If `false` the contents of this field may contain leading and/or trailing non-numeric characters (which implementors `MUST` therefore strip). The purpose of `bareNumber` is to allow publishers to publish numeric data that contains trailing characters such as percentages e.g. `95%` or leading characters such as currencies e.g. `€95` or `EUR 95`. Note that it is entirely up to implementors what, if anything, they do with stripped text.
 
 `format`: no options (other than the default).
@@ -217,8 +217,10 @@ The field contains integers - that is whole numbers.
 
 Integer values are indicated in the standard way for any valid integer.
 
-Additional properties:
+This lexical formatting `MAY` be modified using these additional properties:
 
+- **groupChar**: A string whose value is used to group digits within the
+  integer. This property does not have a default value. A common value is "," e.g. "100,000".
 - **bareNumber**: a boolean field with a default of `true`. If `true` the physical contents of this field `MUST` follow the formatting constraints already set out. If `false` the contents of this field may contain leading and/or trailing non-numeric characters (which implementors `MUST` therefore strip). The purpose of `bareNumber` is to allow publishers to publish numeric data that contains trailing characters such as percentages e.g. `95%` or leading characters such as currencies e.g. `€95` or `EUR 95`. Note that it is entirely up to implementors what, if anything, they do with stripped text.
 
 `format`: no options (other than the default).

--- a/profiles/dictionary/schema.yaml
+++ b/profiles/dictionary/schema.yaml
@@ -378,6 +378,8 @@ tableSchemaFieldInteger:
       default: default
     bareNumber:
       "$ref": "#/definitions/tableSchemaBareNumber"
+    groupChar:
+      "$ref": "#/definitions/tableSchemaGroupChar"
     constraints:
       title: Constraints
       description: The following constraints are supported for `integer` fields.
@@ -452,12 +454,11 @@ tableSchemaFieldNumber:
       default: default
     bareNumber:
       "$ref": "#/definitions/tableSchemaBareNumber"
+    groupChar:
+      "$ref": "#/definitions/tableSchemaGroupChar"
     decimalChar:
       type: string
       description: A string whose value is used to represent a decimal point within the number. The default value is `.`.
-    groupChar:
-      type: string
-      description: A string whose value is used to group digits within the number. The default value is `null`. A common value is `,` e.g. '100,000'.
     constraints:
       title: Constraints
       description: The following constraints are supported for `number` fields.
@@ -1193,3 +1194,7 @@ tableSchemaBareNumber:
   title: bareNumber
   description: a boolean field with a default of `true`. If `true` the physical contents of this field must follow the formatting constraints already set out. If `false` the contents of this field may contain leading and/or trailing non-numeric characters (which implementors MUST therefore strip). The purpose of `bareNumber` is to allow publishers to publish numeric data that contains trailing characters such as percentages e.g. `95%` or leading characters such as currencies e.g. `€95` or `EUR 95`. Note that it is entirely up to implementors what, if anything, they do with stripped text.
   default: true
+tableSchemaGroupChar:
+  type: string
+  title: groupChar
+  description: A string whose value is used to group digits within the number. This property does not have a default value. A common value is `,` e.g. '100,000'.


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/498
- improves "default value" wording

---

# Rationale

Group char character is often used with integers similar to numbers. There is no reason to have this property for numbers but not to have it for integers.