### PR TITLE
Make `contributors[].title` and `sources[].title` not required

### DIFF
--- a/content/docs/specifications/data-package.md
+++ b/content/docs/specifications/data-package.md
@@ -239,9 +239,9 @@ A version string identifying the version of the package. It `SHOULD` conform to 
 
 ##### `sources`
 
-The raw sources for this data package. It `MUST` be an array of Source objects. Each Source object `MUST` have a `title` and `MAY` have `path` and/or `email` properties. Example:
+The raw sources for this data package. It `MUST` be an array of Source objects. A Source object `MUST` have at least one property. A Source object is `RECOMMENDED` to have `title` property and `MAY` contain `path` and `email` properties. Example:
 
-```javascript
+```json
 "sources": [{
   "title": "World Bank and OECD",
   "path": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD"
@@ -254,7 +254,7 @@ The raw sources for this data package. It `MUST` be an array of Source objects. 
 
 ##### `contributors`
 
-The people or organizations who contributed to this Data Package. It `MUST` be an array. Each entry is a Contributor and `MUST` be an `object`. A Contributor `MUST` have at least one property. A Contributor is RECOMMENDED to have `title` property and MAY contain `path`, `email`, `role` and `organization` properties. An example of the object structure is as follows:
+The people or organizations who contributed to this Data Package. It `MUST` be an array. Each entry is a Contributor and `MUST` be an `object`. A Contributor `MUST` have at least one property. A Contributor is RECOMMENDED to have `title` property and MAY contain `path`, `email`, `role`, and `organization` properties. An example of the object structure is as follows:
 
 ```javascript
 "contributors": [{

--- a/content/docs/specifications/data-package.md
+++ b/content/docs/specifications/data-package.md
@@ -254,7 +254,7 @@ The raw sources for this data package. It `MUST` be an array of Source objects. 
 
 ##### `contributors`
 
-The people or organizations who contributed to this Data Package. It `MUST` be an array. Each entry is a Contributor and `MUST` be an `object`. A Contributor `MUST` have a `title` property and MAY contain `path`, `email`, `role` and `organization` properties. An example of the object structure is as follows:
+The people or organizations who contributed to this Data Package. It `MUST` be an array. Each entry is a Contributor and `MUST` be an `object`. A Contributor `MUST` have at least one property. A Contributor is RECOMMENDED to have `title` property and MAY contain `path`, `email`, `role` and `organization` properties. An example of the object structure is as follows:
 
 ```javascript
 "contributors": [{

--- a/profiles/dictionary/common.yaml
+++ b/profiles/dictionary/common.yaml
@@ -199,8 +199,7 @@ contributor:
     role:
       type: string
       default: contributor
-  required:
-    - title
+  minProperties: 1
   context: Use of this property does not imply that the person was the original
     creator of, or a contributor to, the data in the descriptor, but refers to the
     composition of the descriptor itself.
@@ -276,8 +275,7 @@ source:
   title: Source
   description: A source file.
   type: object
-  required:
-    - title
+  minProperties: 1
   properties:
     title:
       "$ref": "#/definitions/title"


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/690

---

# Rationale

In many cases, it's not possible to provide a title, especially during metadata mapping (see the linked issue). At the same time, having at least some information for a contributor or a source still adds an additional value to a published metadata.

Not requiring `title` also opens a way of having custom definitions like:

```
sources:
- "dct:key": value 
```

# Opinion

I don't really have a strong opinion on this one.