### PR TITLE
Added `contributors` property to resource

### DIFF
--- a/content/docs/specifications/data-resource.md
+++ b/content/docs/specifications/data-resource.md
@@ -247,6 +247,7 @@ A descriptor `MAY` contain any number of additional properties. Common propertie
       "hash": "sha1:8843d7f92416211de9ebb963ff4ce28125932878"
 
 - `sources`: as for [Data Package metadata][dp].
+- `contributors`: as for [Data Package metadata][dp].
 - `licenses`: as for [Data Package metadata][dp]. If not specified the resource
   inherits from the data package.
 

--- a/profiles/dictionary/resource.yaml
+++ b/profiles/dictionary/resource.yaml
@@ -41,6 +41,11 @@ dataResource:
       propertyOrder: 140
       options:
         hidden: true
+    contributors:
+      "$ref": "#/definitions/contributors"
+      propertyOrder: 145
+      options:
+        hidden: true
     licenses:
       "$ref": "#/definitions/licenses"
       description: The license(s) under which the resource is published.


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/866

--- 

# Ratonale

Although a data resource can have `licenses` and `sources` similar to a data package, it doesn't have the `contributors` property. Semantically it's not really clear why only 2 of 3 are supported.

# Note

The wording and the way it refers to a Data Package spec needs to be improved later. Currently, we just use an existent pattern