### PR TITLE
Add `version` property to sources

### DIFF
--- a/content/docs/specifications/data-package.md
+++ b/content/docs/specifications/data-package.md
@@ -239,7 +239,7 @@ A version string identifying the version of the package. It `SHOULD` conform to 
 
 ##### `sources`
 
-The raw sources for this data package. It `MUST` be an array of Source objects. Each Source object `MUST` have a `title` and `MAY` have `path` and/or `email` properties. Example:
+The raw sources for this data package. It `MUST` be an array of Source objects. Each Source object `MUST` have a `title` and `MAY` have `path`, `email`, and `version` properties. Example:
 
 ```javascript
 "sources": [{
@@ -251,6 +251,7 @@ The raw sources for this data package. It `MUST` be an array of Source objects. 
 - `title`: title of the source (e.g. document or organization name)
 - `path`: A [url-or-path][] string, that is a fully qualified HTTP address, or a relative POSIX path (see [the url-or-path definition in Data Resource for details][url-or-path]).
 - `email`: An email address
+- `version`: A version of the source
 
 ##### `contributors`
 

--- a/profiles/dictionary/common.yaml
+++ b/profiles/dictionary/common.yaml
@@ -285,6 +285,8 @@ source:
       "$ref": "#/definitions/path"
     email:
       "$ref": "#/definitions/email"
+    version:
+      type: string
 sources:
   title: Sources
   description: The raw sources for this resource.


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/808

--- 

# Rationale

A data source can be versioned and providing this information as a part of a Data Package might be useful for the users