### PR TITLE
Support exclusive constraints in schema

### DIFF
--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -494,6 +494,34 @@ properties.
   </tr>
   <tr>
     <td>
+      <code>exclusiveMinimum</code>
+    </td>
+    <td>
+      integer, number, date, time, datetime, duration, year, yearmonth
+    </td>
+    <td>
+      <code>integer, number, date, time, datetime, duration, year, yearmonth</code>
+    </td>
+    <td>
+      As for <code>minimum</code>, but for expressing exclusive range.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>exclusiveMaximum</code>
+    </td>
+    <td>
+      integer, number, date, time, datetime, duration, year, yearmonth
+    </td>
+    <td>
+      <code>integer, number, date, time, datetime, duration, year, yearmonth</code>
+    </td>
+    <td>
+      As for <code>maximum</code>, but for expressing exclusive range.
+    </td>
+  </tr>
+  <tr>
+    <td>
       <code>pattern</code>
     </td>
     <td>

--- a/profiles/dictionary/schema.yaml
+++ b/profiles/dictionary/schema.yaml
@@ -399,6 +399,14 @@ tableSchemaFieldInteger:
           oneOf:
             - "$ref": "#/definitions/tableSchemaConstraintMaximumString"
             - "$ref": "#/definitions/tableSchemaConstraintMaximumInteger"
+        exclusiveMinimum:
+          oneOf:
+            - "$ref": "#/definitions/tableSchemaConstraintMinimumString"
+            - "$ref": "#/definitions/tableSchemaConstraintMinimumInteger"
+        exclusiveMaximum:
+          oneOf:
+            - "$ref": "#/definitions/tableSchemaConstraintMaximumString"
+            - "$ref": "#/definitions/tableSchemaConstraintMaximumInteger"
     rdfType:
       "$ref": "#/definitions/tableSchemaRdfType"
   examples:
@@ -479,6 +487,14 @@ tableSchemaFieldNumber:
           oneOf:
             - "$ref": "#/definitions/tableSchemaConstraintMaximumString"
             - "$ref": "#/definitions/tableSchemaConstraintMaximumNumber"
+        exclusiveMinimum:
+          oneOf:
+            - "$ref": "#/definitions/tableSchemaConstraintMinimumString"
+            - "$ref": "#/definitions/tableSchemaConstraintMinimumNumber"
+        exclusiveMaximum:
+          oneOf:
+            - "$ref": "#/definitions/tableSchemaConstraintMaximumString"
+            - "$ref": "#/definitions/tableSchemaConstraintMaximumNumber"
     rdfType:
       "$ref": "#/definitions/tableSchemaRdfType"
   examples:
@@ -537,6 +553,10 @@ tableSchemaFieldDate:
         minimum:
           "$ref": "#/definitions/tableSchemaConstraintMinimumString"
         maximum:
+          "$ref": "#/definitions/tableSchemaConstraintMaximumString"
+        exclusiveMinimum:
+          "$ref": "#/definitions/tableSchemaConstraintMinimumString"
+        exclusiveMaximum:
           "$ref": "#/definitions/tableSchemaConstraintMaximumString"
     rdfType:
       "$ref": "#/definitions/tableSchemaRdfType"
@@ -603,6 +623,10 @@ tableSchemaFieldTime:
           "$ref": "#/definitions/tableSchemaConstraintMinimumString"
         maximum:
           "$ref": "#/definitions/tableSchemaConstraintMaximumString"
+        exclusiveMinimum:
+          "$ref": "#/definitions/tableSchemaConstraintMinimumString"
+        exclusiveMaximum:
+          "$ref": "#/definitions/tableSchemaConstraintMaximumString"
     rdfType:
       "$ref": "#/definitions/tableSchemaRdfType"
   examples:
@@ -659,6 +683,10 @@ tableSchemaFieldDateTime:
         minimum:
           "$ref": "#/definitions/tableSchemaConstraintMinimumString"
         maximum:
+          "$ref": "#/definitions/tableSchemaConstraintMaximumString"
+        exclusiveMinimum:
+          "$ref": "#/definitions/tableSchemaConstraintMinimumString"
+        exclusiveMaximum:
           "$ref": "#/definitions/tableSchemaConstraintMaximumString"
     rdfType:
       "$ref": "#/definitions/tableSchemaRdfType"
@@ -721,6 +749,14 @@ tableSchemaFieldYear:
           oneOf:
             - "$ref": "#/definitions/tableSchemaConstraintMaximumString"
             - "$ref": "#/definitions/tableSchemaConstraintMaximumInteger"
+        exclusiveMinimum:
+          oneOf:
+            - "$ref": "#/definitions/tableSchemaConstraintMinimumString"
+            - "$ref": "#/definitions/tableSchemaConstraintMinimumInteger"
+        exclusiveMaximum:
+          oneOf:
+            - "$ref": "#/definitions/tableSchemaConstraintMaximumString"
+            - "$ref": "#/definitions/tableSchemaConstraintMaximumInteger"
     rdfType:
       "$ref": "#/definitions/tableSchemaRdfType"
   examples:
@@ -778,6 +814,10 @@ tableSchemaFieldYearMonth:
         minimum:
           "$ref": "#/definitions/tableSchemaConstraintMinimumString"
         maximum:
+          "$ref": "#/definitions/tableSchemaConstraintMaximumString"
+        exclusiveMinimum:
+          "$ref": "#/definitions/tableSchemaConstraintMinimumString"
+        exclusiveMaximum:
           "$ref": "#/definitions/tableSchemaConstraintMaximumString"
     rdfType:
       "$ref": "#/definitions/tableSchemaRdfType"
@@ -837,6 +877,10 @@ tableSchemaFieldDuration:
         minimum:
           "$ref": "#/definitions/tableSchemaConstraintMinimumString"
         maximum:
+          "$ref": "#/definitions/tableSchemaConstraintMaximumString"
+        exclusiveMinimum:
+          "$ref": "#/definitions/tableSchemaConstraintMinimumString"
+        exclusiveMaximum:
           "$ref": "#/definitions/tableSchemaConstraintMaximumString"
     rdfType:
       "$ref": "#/definitions/tableSchemaRdfType"


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/856

---

# Rationale

Although in the linked discussion there are valid arguments for using a `hack` instead of adding new constraints, I think that's just **the right thing to do** as the range and exclusive range are two standard constraints for numeric types (see JSONSchema - https://json-schema.org/understanding-json-schema/reference/numeric). New constraints are relatively simple to support in implementations