### PR TITLE
Added `finiteNumber` property for numbers

### DIFF
--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -206,6 +206,7 @@ This lexical formatting `MAY` be modified using these additional properties:
 - **groupChar**: A string whose value is used to group digits within the
   number. The default value is null. A common value is "," e.g. "100,000".
 - **bareNumber**: a boolean field with a default of `true`. If `true` the physical contents of this field `MUST` follow the formatting constraints already set out. If `false` the contents of this field may contain leading and/or trailing non-numeric characters (which implementors `MUST` therefore strip). The purpose of `bareNumber` is to allow publishers to publish numeric data that contains trailing characters such as percentages e.g. `95%` or leading characters such as currencies e.g. `€95` or `EUR 95`. Note that it is entirely up to implementors what, if anything, they do with stripped text.
+- **finiteNumber**: a boolean property with a default of `true`. If `true` the `NaN`, `INF`, and `-INF` values are not allowed
 
 `format`: no options (other than the default).
 

--- a/profiles/dictionary/schema.yaml
+++ b/profiles/dictionary/schema.yaml
@@ -452,6 +452,8 @@ tableSchemaFieldNumber:
       default: default
     bareNumber:
       "$ref": "#/definitions/tableSchemaBareNumber"
+    finiteNumber:
+      "$ref": "#/definitions/tableSchemaFiniteNumber"
     decimalChar:
       type: string
       description: A string whose value is used to represent a decimal point within the number. The default value is `.`.
@@ -1192,4 +1194,7 @@ tableSchemaBareNumber:
   type: boolean
   title: bareNumber
   description: a boolean field with a default of `true`. If `true` the physical contents of this field must follow the formatting constraints already set out. If `false` the contents of this field may contain leading and/or trailing non-numeric characters (which implementors MUST therefore strip). The purpose of `bareNumber` is to allow publishers to publish numeric data that contains trailing characters such as percentages e.g. `95%` or leading characters such as currencies e.g. `€95` or `EUR 95`. Note that it is entirely up to implementors what, if anything, they do with stripped text.
+  default: true
+tableSchemaFiniteNumber:
+  type: boolean
   default: true


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/644

---

# Rationale

Support of `NaN`, `INF`, and `-INF` is really neither cross-platform, nor predictable from backend to backend. This new property will at least make them disabled by default

# Note

This change is semantically breaking for very rare use cases although it's structurally not-breaking for implementations