### PR TITLE
Clarified `schema.fields` property

### DIFF
--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -69,7 +69,7 @@ For example, `constraints` `SHOULD` be tested on the logical representation of d
 
 A Table Schema is represented by a descriptor. The descriptor `MUST` be a JSON `object` (JSON is defined in [RFC 4627](http://www.ietf.org/rfc/rfc4627.txt)).
 
-It `MUST` contain a property `fields`. `fields` `MUST` be an array where each entry in the array is a field descriptor (as defined below). The order of elements in `fields` array `SHOULD` be the order of fields in the CSV file. The number of elements in `fields` array `SHOULD` be the same as the number of fields in the CSV file.
+It `MUST` contain a property `fields`. `fields` `MUST` be an array where each entry in the array is a field descriptor (as defined below). The order of elements in `fields` array `MUST` be the order of fields in the data source. The number of elements in `fields` array `MUST` be the same as the number of fields in data source. For unordered data sources the order of fields `SHOULD` be specified in Table Dialect, otherwise the behavior is implementation-specific.
 
 The descriptor `MAY` have the additional properties set out below and `MAY` contain any number of other properties (not defined in this specification).
 


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/367

---

# Rationale

It's been a while Table Schema has had this ambiguity of the `schema.fields` property. I think it's a good point to finally clarify that:
- fields are strictly order based
- fields have to cover all the data columns

Without this clarity it's basically not possible to create a reliable implementation (meaning "no interoperability"). Of course, in the real world, the existent implementation already assumed both points as far as I know. 

# Comment

Throughout the time, we saw many requests and use cases that had optional fields or a requirement to order fields. Most of them can be handled on the implementation level as an additional feature, but, of course, the Table Schema spec might consider adding a new feature like `schema.fieldsMap` or something like this but I believe it just needs to be a different thing not `schema.fields` and also it should be really justified as, in-general, Data Package Standard is for describing data, not for transforming data (while cherry-picking fields is kind of transformation)

