### PR TITLE
Forbid hidden folders in the spec (already forbidden in JSON Schema)

### DIFF
--- a/content/docs/specifications/data-resource.md
+++ b/content/docs/specifications/data-resource.md
@@ -109,7 +109,7 @@ A "url-or-path" is a `string` with the following additional constraints:
 
 - `MUST` either be a URL or a POSIX path
 - [URLs][url] `MUST` be fully qualified. `MUST` be using either http or https scheme. (Absence of a scheme indicates `MUST` be a POSIX path)
-- [POSIX paths][posix] (unix-style with `/` as separator) are supported for referencing local files, with the security restraint that they `MUST` be relative siblings or children of the descriptor. Absolute paths (/) and relative parent paths (../) `MUST` NOT be used, and implementations SHOULD NOT support these path types.
+- [POSIX paths][posix] (unix-style with `/` as separator) are supported for referencing local files, with the security restraint that they `MUST` be relative siblings or children of the descriptor. Absolute paths `/`, relative parent paths `../`, hidden folders starting from a dot `.hidden` `MUST` NOT be used, and implementations `SHOULD NOT` support these path types.
 
 [url]: https://en.wikipedia.org/wiki/Uniform_Resource_Locator
 [posix]: https://en.wikipedia.org/wiki/Path_%28computing%29#POSIX_pathname_definition

--- a/content/docs/specifications/data-resource.md
+++ b/content/docs/specifications/data-resource.md
@@ -109,7 +109,7 @@ A "url-or-path" is a `string` with the following additional constraints:
 
 - `MUST` either be a URL or a POSIX path
 - [URLs][url] `MUST` be fully qualified. `MUST` be using either http or https scheme. (Absence of a scheme indicates `MUST` be a POSIX path)
-- [POSIX paths][posix] (unix-style with `/` as separator) are supported for referencing local files, with the security restraint that they `MUST` be relative siblings or children of the descriptor. Absolute paths `/`, relative parent paths `../`, hidden folders starting from a dot `.hidden` `MUST` NOT be used, and implementations `SHOULD NOT` support these path types.
+- [POSIX paths][posix] (unix-style with `/` as separator) are supported for referencing local files, with the security restraint that they `MUST` be relative siblings or children of the descriptor. Absolute paths `/`, relative parent paths `../`, hidden folders starting from a dot `.hidden` `MUST` NOT be used.
 
 [url]: https://en.wikipedia.org/wiki/Uniform_Resource_Locator
 [posix]: https://en.wikipedia.org/wiki/Path_%28computing%29#POSIX_pathname_definition


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/802

---

# Rationale

See https://github.com/frictionlessdata/specs/issues/802. Note that although it's forbidden for data publishing it's ok for implementations to support it for local work (e.g. `frictionless-py` has `trusted` flag) 