### PR TITLE
Relax `resource.name` requirements

### DIFF
--- a/content/docs/specifications/data-package.md
+++ b/content/docs/specifications/data-package.md
@@ -146,7 +146,7 @@ In addition to the required properties, the following properties `SHOULD` be inc
 
 ##### `name`
 
-A short url-usable (and preferably human-readable) name of the package. This `MUST` be lower-case and contain only alphanumeric characters along with ".", "\_" or "-" characters. It will function as a unique identifier and therefore `SHOULD` be unique in relation to any registry in which this package will be deposited (and preferably globally unique).
+A short url-usable (and preferably human-readable) name of the package. This `SHOULD` be lower-case and contain only alphanumeric characters along with ".", "\_" or "-" characters. It will function as a unique identifier and therefore `SHOULD` be unique in relation to any registry in which this package will be deposited (and preferably globally unique).
 
 The name `SHOULD` be invariant, meaning that it `SHOULD NOT` change when a data package is updated, unless the new package version `SHOULD` be considered a distinct package, e.g. due to significant changes in structure or interpretation. Version distinction `SHOULD` be left to the version property. As a corollary, the name also `SHOULD NOT` include an indication of time range covered.
 

--- a/content/docs/specifications/data-resource.md
+++ b/content/docs/specifications/data-resource.md
@@ -191,22 +191,17 @@ Thus, a consumer of resource object `MAY` assume if no format or mediatype prope
 
 ### Metadata Properties
 
-#### Required Properties
-
-A descriptor `MUST` contain the following properties:
+#### Recommended Properties
 
 #### `name`
 
-A resource `MUST` contain a `name` property. The name is a simple name or
+A resource `SHOULD` contain a `name` property. The name is a simple name or
 identifier to be used for this resource.
 
-- If present, the name `MUST` be unique amongst all resources in this data
-  package.
-- It `MUST` consist only of lowercase alphanumeric characters plus ".", "-" and "\_".
+- If present, the name `SHOULD` be unique amongst all resources in this data package.
+- It `SHOULD` consist only of lowercase alphanumeric characters plus ".", "-" and "\_".
 - It would be usual for the name to correspond to the file name (minus the
   extension) of the data file the resource describes.
-
-#### Recommended Properties
 
 #### `profile`
 

--- a/profiles/dictionary/common.yaml
+++ b/profiles/dictionary/common.yaml
@@ -15,9 +15,8 @@ profile:
       }
 name:
   title: Name
-  description: An identifier string. Lower case characters with `.`, `_`, `-` and `/` are allowed.
+  description: An identifier string
   type: string
-  pattern: "^([-a-z0-9._/])+$"
   context: This is ideally a url-usable and human-readable name. Name `SHOULD` be
     invariant, meaning it `SHOULD NOT` change when its parent descriptor is updated.
   examples:

--- a/profiles/dictionary/resource.yaml
+++ b/profiles/dictionary/resource.yaml
@@ -4,10 +4,8 @@ dataResource:
   type: object
   oneOf:
     - required:
-        - name
         - data
     - required:
-        - name
         - path
   properties:
     profile:


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/685

---

# Rationale

Please see the attached issue for more context. Personally, I have two arguments to justify this change:

First of all, as a Data Package implementor in `frictionless-py` and Open Data Editor, I have to say that dealing with `resource.name` mandatory, sluggishness, and uniqueness is just a nightmare. It starts from small things but forms a snowball of problems step by step. Like a user adding a resource, shall we fail on non-unique name, shall we implicitly make it unique, then different mappers (CKAN/Zenodo/etc) come to play complicating it more, etc If `resource.name` were at least SQL-compliant so you can directly use it for uploading to the database it would make more sense for me for managing the complexity but it's not SQL-compliant already and only can be used for resource random access and foreign key referencing BUT they are just features, and they are not always relevant. If as a data publisher you'd like use these features (access/fks) you are free to make `resource.name` required and unique. Right? But not everyone needs it, in my opinion  (it can be a flag on the implementation level).

Secondly, here is an example -- Our World in Data exports a lot of datasets as data packages - https://github.com/owid/owid-datasets/blob/master/datasets/Child%20Marriage%20%E2%80%93%20UNICEF%20(2017)/datapackage.json. Those data packages are perfectly readable and validatable. So publishing them creates a lot of added value BUT they are all invalid because there is no `resource.name`. The thing that both e.g. OWID don't need a name here to publish it and e.g. Open Data Editor doesn't need a name here to read it. In my opinion, this case show that `resource.name` requirements should be relaxed