### PR TITLE
Relax `resource.name` rules but keep it required and unique

### DIFF
--- a/content/docs/specifications/data-package.md
+++ b/content/docs/specifications/data-package.md
@@ -146,7 +146,7 @@ In addition to the required properties, the following properties `SHOULD` be inc
 
 ##### `name`
 
-A short url-usable (and preferably human-readable) name of the package. This `MUST` be lower-case and contain only alphanumeric characters along with ".", "\_" or "-" characters. It will function as a unique identifier and therefore `SHOULD` be unique in relation to any registry in which this package will be deposited (and preferably globally unique).
+A short url-usable (and preferably human-readable) name of the package. This `SHOULD` be lower-case and contain only alphanumeric characters along with ".", "\_" or "-" characters. It will function as a unique identifier and therefore `SHOULD` be unique in relation to any registry in which this package will be deposited (and preferably globally unique).
 
 The name `SHOULD` be invariant, meaning that it `SHOULD NOT` change when a data package is updated, unless the new package version `SHOULD` be considered a distinct package, e.g. due to significant changes in structure or interpretation. Version distinction `SHOULD` be left to the version property. As a corollary, the name also `SHOULD NOT` include an indication of time range covered.
 

--- a/content/docs/specifications/data-package.md
+++ b/content/docs/specifications/data-package.md
@@ -146,9 +146,11 @@ In addition to the required properties, the following properties `SHOULD` be inc
 
 ##### `name`
 
-A short url-usable (and preferably human-readable) name of the package. This `SHOULD` be lower-case and contain only alphanumeric characters along with ".", "\_" or "-" characters. It will function as a unique identifier and therefore `SHOULD` be unique in relation to any registry in which this package will be deposited (and preferably globally unique).
+The name is a simple name or identifier to be used for this package in relation to any registry in which this package will be deposited.
 
-The name `SHOULD` be invariant, meaning that it `SHOULD NOT` change when a data package is updated, unless the new package version `SHOULD` be considered a distinct package, e.g. due to significant changes in structure or interpretation. Version distinction `SHOULD` be left to the version property. As a corollary, the name also `SHOULD NOT` include an indication of time range covered.
+- It `SHOULD` be human-readable and consist only of lowercase alphanumeric characters plus ".", "-" and "\_".
+- It `SHOULD` be unique in relation to any registry in which this package will be deposited (and preferably globally unique).
+- It `SHOULD` be invariant, meaning that it `SHOULD NOT` change when a data package is updated, unless the new package version `SHOULD` be considered a distinct package, e.g. due to significant changes in structure or interpretation. Version distinction `SHOULD` be left to the version property. As a corollary, the name also `SHOULD NOT` include an indication of time range covered.
 
 ##### `id`
 

--- a/content/docs/specifications/data-resource.md
+++ b/content/docs/specifications/data-resource.md
@@ -193,6 +193,8 @@ Thus, a consumer of resource object `MAY` assume if no format or mediatype prope
 
 #### Required Properties
 
+A descriptor `MUST` contain the following properties:
+
 #### `name`
 
 A resource `MUST` contain a `name` property. The name is a simple name or identifier to be used for this resource.

--- a/content/docs/specifications/data-resource.md
+++ b/content/docs/specifications/data-resource.md
@@ -191,22 +191,17 @@ Thus, a consumer of resource object `MAY` assume if no format or mediatype prope
 
 ### Metadata Properties
 
-#### Required Properties
-
-A descriptor `MUST` contain the following properties:
+#### Recommended Properties
 
 #### `name`
 
-A resource `MUST` contain a `name` property. The name is a simple name or
+A resource `SHOULD` contain a `name` property. The name is a simple name or
 identifier to be used for this resource.
 
-- If present, the name `MUST` be unique amongst all resources in this data
-  package.
-- It `MUST` consist only of lowercase alphanumeric characters plus ".", "-" and "\_".
+- If present, the name `SHOULD` be unique amongst all resources in this data package.
+- It `SHOULD` consist only of lowercase alphanumeric characters plus ".", "-" and "\_".
 - It would be usual for the name to correspond to the file name (minus the
   extension) of the data file the resource describes.
-
-#### Recommended Properties
 
 #### `profile`
 

--- a/content/docs/specifications/data-resource.md
+++ b/content/docs/specifications/data-resource.md
@@ -191,16 +191,17 @@ Thus, a consumer of resource object `MAY` assume if no format or mediatype prope
 
 ### Metadata Properties
 
-#### Recommended Properties
+#### Required Properties
 
 #### `name`
 
 A resource `MUST` contain a `name` property. The name is a simple name or identifier to be used for this resource.
 
-- If present, the name `SHOULD` be unique amongst all resources in this data package.
-- It `SHOULD` consist only of lowercase alphanumeric characters plus ".", "-" and "\_".
-- It would be usual for the name to correspond to the file name (minus the
-  extension) of the data file the resource describes.
+- It `MUST` be unique amongst all resources in this data package.
+- It `SHOULD` be human-readable and consist only of lowercase alphanumeric characters plus ".", "-" and "\_".
+- It would be usual for the name to correspond to the file name (minus the extension) of the data file the resource describes.
+
+#### Recommended Properties
 
 #### `profile`
 

--- a/content/docs/specifications/data-resource.md
+++ b/content/docs/specifications/data-resource.md
@@ -195,8 +195,7 @@ Thus, a consumer of resource object `MAY` assume if no format or mediatype prope
 
 #### `name`
 
-A resource `SHOULD` contain a `name` property. The name is a simple name or
-identifier to be used for this resource.
+A resource `MUST` contain a `name` property. The name is a simple name or identifier to be used for this resource.
 
 - If present, the name `SHOULD` be unique amongst all resources in this data package.
 - It `SHOULD` consist only of lowercase alphanumeric characters plus ".", "-" and "\_".

--- a/profiles/dictionary/common.yaml
+++ b/profiles/dictionary/common.yaml
@@ -15,7 +15,7 @@ profile:
       }
 name:
   title: Name
-  description: An identifier string
+  description: An identifier string.
   type: string
   context: This is ideally a url-usable and human-readable name. Name `SHOULD` be
     invariant, meaning it `SHOULD NOT` change when its parent descriptor is updated.

--- a/profiles/dictionary/common.yaml
+++ b/profiles/dictionary/common.yaml
@@ -15,9 +15,8 @@ profile:
       }
 name:
   title: Name
-  description: An identifier string. Lower case characters with `.`, `_`, `-` and `/` are allowed.
+  description: An identifier string
   type: string
-  pattern: "^([-a-z0-9._/])+$"
   context: This is ideally a url-usable and human-readable name. Name `SHOULD` be
     invariant, meaning it `SHOULD NOT` change when its parent descriptor is updated.
   examples:

--- a/profiles/dictionary/resource.yaml
+++ b/profiles/dictionary/resource.yaml
@@ -4,8 +4,10 @@ dataResource:
   type: object
   oneOf:
     - required:
+        - name
         - data
     - required:
+        - name
         - path
   properties:
     profile:

--- a/profiles/dictionary/resource.yaml
+++ b/profiles/dictionary/resource.yaml
@@ -4,10 +4,8 @@ dataResource:
   type: object
   oneOf:
     - required:
-        - name
         - data
     - required:
-        - name
         - path
   properties:
     profile:


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/685

---

# Rationale

It's a fixed version of #21. In this edition, `resource.name` and `field.name` will have the same level of requirements (making it quite nice symmetry across the specs). Please see the reasons for relaxing the rules in the linked issue and PR.