### PR TITLE
Add `uniqueKeys` property to Table Schema

### DIFF
--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -672,7 +672,7 @@ All the field values that are on the logical level are considered to be `null` v
 
 #### Relation to `constraints.unique`
 
-The `uniqueKeys` and `field.constraints.unique` are independent ways of defining uniqueness of field values. A data consumer `MUST` check all of the applied constraints separately.
+In contrast with `field.constraints.unique`, `uniqueKeys` allows to define uniqueness as a combination of fields. Both properties `SHOULD` be assessed separately.
 
 ### Foreign Keys
 

--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -637,7 +637,7 @@ Here's an example with an array primary key:
 
 A unique key is a field or a set of fields that are required to have unique logical values in each row in the table. It is directly modeled on the concept of unique constraint in SQL.
 
-The `uniqueKeys` property, if present, `MUST` be an array. Each entry in the array `MUST` be a `uniqueKey`. A `uniqueKey` `MUST` be an array of strings with each string corresponding to one of the field `name` values in the `fields` array, denoting that the unique key is made up of those fields. It is acceptable to have an array with a single value, indicating just one field in the unique key.
+The `uniqueKeys` property, if present, `MUST` be a non-empty array. Each entry in the array `MUST` be a `uniqueKey`. A `uniqueKey` `MUST` be an array of strings with each string corresponding to one of the field `name` values in the `fields` array, denoting that the unique key is made up of those fields. It is acceptable to have an array with a single value, indicating just one field in the unique key.
 
 An example of using the `uniqueKeys` property:
 

--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -633,6 +633,48 @@ Here's an example with an array primary key:
       "primaryKey": ["a", "c"]
      }
 
+### Unique Keys
+
+A unique key is a field or a set of fields that are required to have unique logical values in each row in the table. It is directly modeled on the concept of unique constraint in SQL.
+
+The `uniqueKeys` property, if present, `MUST` be an Array. Each entry in the array `MUST` be a `uniqueKey`. A `uniqueKey` `MUST` be an array of strings with each string corresponding to one of the field `name` values in the `fields` array, denoting that the unique key is made up of those fields. It is acceptable to have an array with a single value, indicating just one field in the unique key.
+
+An example of using the `uniqueKeys` property:
+
+```json
+"fields": [
+  {
+    "name": "a"
+  },
+  {
+    "name": "b"
+  },
+  {
+    "name": "c"
+  },
+  ...
+],
+"uniqueKeys": [
+  ["a"],
+  ["a", "b"],
+  ["a", "c"],
+]
+```
+
+In the case of the definition above, the data in the table has to be considered valid only if:
+
+- each row has a unique logical value in the field `a`
+- each row has a unique set of logical values in the fields `a` and `b`
+- each row has a unique set of logical values in the fields `a` and `c`
+
+#### Handling `null` values
+
+All the field values that are on the logical level are considered to be `null` values `MUST` be excluded from the uniqueness check, as the `uniqueKeys` property is modeled on the concept of unique constraint in SQL.
+
+#### Relation to `constraints.unique`
+
+The `uniqueKeys` and `field.constraints.unique` are independent ways of defining uniqueness of field values. A data consumer `MUST` check all of the applied constraints separately.
+
 ### Foreign Keys
 
 A foreign key is a reference where values in a field (or fields) on the

--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -637,7 +637,7 @@ Here's an example with an array primary key:
 
 A unique key is a field or a set of fields that are required to have unique logical values in each row in the table. It is directly modeled on the concept of unique constraint in SQL.
 
-The `uniqueKeys` property, if present, `MUST` be an Array. Each entry in the array `MUST` be a `uniqueKey`. A `uniqueKey` `MUST` be an array of strings with each string corresponding to one of the field `name` values in the `fields` array, denoting that the unique key is made up of those fields. It is acceptable to have an array with a single value, indicating just one field in the unique key.
+The `uniqueKeys` property, if present, `MUST` be an array. Each entry in the array `MUST` be a `uniqueKey`. A `uniqueKey` `MUST` be an array of strings with each string corresponding to one of the field `name` values in the `fields` array, denoting that the unique key is made up of those fields. It is acceptable to have an array with a single value, indicating just one field in the unique key.
 
 An example of using the `uniqueKeys` property:
 

--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -656,7 +656,7 @@ An example of using the `uniqueKeys` property:
 "uniqueKeys": [
   ["a"],
   ["a", "b"],
-  ["b", "c"]
+  ["a", "c"]
 ]
 ```
 

--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -651,13 +651,12 @@ An example of using the `uniqueKeys` property:
   },
   {
     "name": "c"
-  },
-  ...
+  }
 ],
 "uniqueKeys": [
   ["a"],
   ["a", "b"],
-  ["a", "c"],
+  ["b", "c"]
 ]
 ```
 

--- a/profiles/dictionary/schema.yaml
+++ b/profiles/dictionary/schema.yaml
@@ -42,6 +42,8 @@ tableSchema:
           }
     primaryKey:
       "$ref": "#/definitions/tableSchemaPrimaryKey"
+    uniqueKeys:
+      "$ref": "#/definitions/tableSchemaUniqueKeys"
     foreignKeys:
       type: array
       minItems: 1
@@ -141,6 +143,12 @@ tableSchemaPrimaryKey:
           "last_name"
         ]
       }
+tableSchemaUniqueKeys:
+  type: array
+  minItems: 1
+  uniqueItems: true
+  items:
+    type: string
 tableSchemaForeignKey:
   title: Table Schema Foreign Key
   description: Table Schema Foreign Key

--- a/profiles/dictionary/schema.yaml
+++ b/profiles/dictionary/schema.yaml
@@ -148,7 +148,11 @@ tableSchemaUniqueKeys:
   minItems: 1
   uniqueItems: true
   items:
-    type: string
+    type: array
+    minItems: 1
+    uniqueItems: true
+    items:
+      type: string
 tableSchemaForeignKey:
   title: Table Schema Foreign Key
   description: Table Schema Foreign Key


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/862

---

# Rationale

Requiring multiple field uniqueness is a vital part of data modeling. This proposal is based on the [Unique Constraints pattern](http://localhost:8080/patterns/unique-constraints/) but updated to be compatible with the SQL standard.