### PR TITLE
Added `arrayItem` property

### DIFF
--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -248,6 +248,39 @@ The field contains data that is a valid JSON format arrays.
 
 `format`: no options (other than the default).
 
+Additional properties:
+
+- **arrayItem**: an array field can be customized by the `arrayItem` property. If provided, `arrayItem` `MUST` be a `field`, an object describing a field as per the Table Schema specification (TODO: cross-link when `field` is a linkable entity). Each array item `MUST` conform to the provided field definition.
+
+An example of using the `arrayItem` property:
+
+```json
+"fields": [
+  {
+    "name": "id",
+    "type": "string"
+  },
+  {
+    "name": "array",
+    "type": "array"
+    "arrayItem": {
+      "name": "value",
+      "type": "integer"
+    }
+  },
+]
+```
+
+In the case of the definition above, the valid data table might look as below:
+
+```json
+[
+  ["id", "array"],
+  ["row1", [11, 12]]
+  ["row2", [21, 22]]
+]
+```
+
 #### date
 
 A date without a time.

--- a/profiles/dictionary/schema.yaml
+++ b/profiles/dictionary/schema.yaml
@@ -965,6 +965,9 @@ tableSchemaFieldArray:
       enum:
         - default
       default: default
+    # TODO: expand when rebased on JSON Schema definitions
+    arrayItem:
+      type: object
     constraints:
       title: Constraints
       description: The following constraints apply for `array` fields.


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/409

---

# Rationale

Please see the attached discussion.

# Problems

It's not clear how to define the property in JSON Schema as current build system doesn't output JSON Schema definitions.

# Implementations

- https://github.com/frictionlessdata/frictionless-py/blob/main/tests/fields/test_array.py#L36-L63