### PR TITLE
Added `jsonSchema` constraint to `object` and `array` fields

### DIFF
--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -238,7 +238,7 @@ The boolean field can be customised with these additional properties:
 
 #### object
 
-The field contains data which is valid JSON format objects.
+A valid JSON object.
 
 `format`: no options (other than the default).
 

--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -238,9 +238,13 @@ The boolean field can be customised with these additional properties:
 
 #### object
 
-The field contains data which is valid JSON.
+The field contains data which is valid JSON format objects.
 
 `format`: no options (other than the default).
+
+Additional properties:
+
+- **jsonSchema**: an object field can be customized by `jsonSchema` property. If provided, `jsonSchema` `MUST` be a valid JSON Schema object and the field's values in each row `MUST` conform to this JSON Schema.
 
 #### array
 

--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -264,17 +264,13 @@ The boolean field can be customised with these additional properties:
 
 #### object
 
-A valid JSON object.
+The field contains a valid JSON object.
 
 `format`: no options (other than the default).
 
-Additional properties:
-
-- **jsonSchema**: an object field can be customized by `jsonSchema` property. If provided, `jsonSchema` `MUST` be a valid JSON Schema object and the field's values in each row `MUST` conform to this JSON Schema.
-
 #### array
 
-The field contains data that is a valid JSON format arrays.
+The field contains a valid JSON array.
 
 `format`: no options (other than the default).
 
@@ -538,6 +534,19 @@ properties.
     </td>
     <td>
       As for <code>maximum</code>, but for expressing exclusive range.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>jsonSchema</code>
+    </td>
+    <td>
+      object
+    </td>
+    <td>
+      <code>array</code>, <code>object</code>
+    </td>
+    <td>A valid JSON Schema object to validate field values. If a field value conforms to the provided JSON Schema then this field value is valid.
     </td>
   </tr>
   <tr>

--- a/profiles/dictionary/schema.yaml
+++ b/profiles/dictionary/schema.yaml
@@ -950,8 +950,6 @@ tableSchemaFieldObject:
       enum:
         - default
       default: default
-    jsonSchema:
-      type: object
     constraints:
       title: Constraints
       description: The following constraints apply for `object` fields.
@@ -969,6 +967,8 @@ tableSchemaFieldObject:
           "$ref": "#/definitions/tableSchemaConstraintMinLength"
         maxLength:
           "$ref": "#/definitions/tableSchemaConstraintMaxLength"
+        jsonSchema:
+          "$ref": "#/definitions/tableSchemaConstraintJsonSchema"
     rdfType:
       "$ref": "#/definitions/tableSchemaRdfType"
   examples:
@@ -1021,6 +1021,8 @@ tableSchemaFieldArray:
           "$ref": "#/definitions/tableSchemaConstraintMinLength"
         maxLength:
           "$ref": "#/definitions/tableSchemaConstraintMaxLength"
+        jsonSchema:
+          "$ref": "#/definitions/tableSchemaConstraintJsonSchema"
     rdfType:
       "$ref": "#/definitions/tableSchemaRdfType"
   examples:
@@ -1204,6 +1206,9 @@ tableSchemaConstraintRequired:
 tableSchemaConstraintUnique:
   type: boolean
   description: When `true`, each value for the property `MUST` be unique.
+tableSchemaConstraintJsonSchema:
+  type: object
+  description: A valid JSON Schema object to validate field values. If a field value conforms to the provided JSON Schema then this field value is valid.
 tableSchemaConstraintPattern:
   type: string
   description: A regular expression pattern to test each value of the property against, where a truthy response indicates validity.

--- a/profiles/dictionary/schema.yaml
+++ b/profiles/dictionary/schema.yaml
@@ -915,6 +915,8 @@ tableSchemaFieldObject:
       enum:
         - default
       default: default
+    jsonSchema:
+      type: object
     constraints:
       title: Constraints
       description: The following constraints apply for `object` fields.


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/640

---

# Rationale

Please see the attached issue.

# Note

I think the initial wording didn't mention that `object` needs to be an object, not just JSON by mistake. It's been fixed here.