### PR TITLE
Clarify numeric precision and add `exactNumber` property

### DIFF
--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -206,10 +206,15 @@ This lexical formatting `MAY` be modified using these additional properties:
 - **groupChar**: A string whose value is used to group digits within the
   number. The default value is null. A common value is "," e.g. "100,000".
 - **bareNumber**: a boolean field with a default of `true`. If `true` the physical contents of this field `MUST` follow the formatting constraints already set out. If `false` the contents of this field may contain leading and/or trailing non-numeric characters (which implementors `MUST` therefore strip). The purpose of `bareNumber` is to allow publishers to publish numeric data that contains trailing characters such as percentages e.g. `95%` or leading characters such as currencies e.g. `€95` or `EUR 95`. Note that it is entirely up to implementors what, if anything, they do with stripped text.
+- **exactNumber**: a boolean property with a default of `false`. If `true` a data consumer `MUST` use an [infinite precision data type](https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic) to operate with the logical values in the field.
 
 `format`: no options (other than the default).
 
 [xsd-decimal]: https://www.w3.org/TR/xmlschema-2/#decimal
+
+##### Numeric Precision
+
+By default, similar to the `JSON` standard, Table Schema specification does not define precision for numeric values. Each implementation has to choose the best available data type to represent logical numbers based on the platform-specifics, performance, and user configuration factors. To guarantee numeric values exactness and arbitrary precision arithmetic, a data producer `MUST` set `exactNumber` property to `true`.
 
 #### integer
 


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/709

---

# Rationale 

In v1, Table Schema doesn't say anything about numeric precision, which might be OK (e.g. [JSON does the same](https://stackoverflow.com/questions/35709595/why-would-you-use-a-string-in-json-to-represent-a-decimal-number)) but it makes the specification really not suitable for any data that requires lossless arithmetic e.g. monetary data.

This proposal tries to provide the simplest solution to enable the ability to guarantee numeric exactness and, at the same time,  clarify precision expectations by default. The approach is backward-compatible as it adds a new property. 

Note that for historical reasons, `frictionless-py` already uses `Decimal` (lossless) data type for all numbers, which is very inefficient performance-wise. With the proposed clarification, it will be acceptable but not recommended behavior.  

PS.
The name for the new property intentionally has been chosen outside of `precision/float/double/etc` terminology to ensure that it's on the other level of abstraction (to avoid falling into the [rabbit hole](https://github.com/frictionlessdata/specs/issues/709#issuecomment-708278539) of physical number representation in the memory)    