### PR TITLE
Use `self` instead of an empty string for foreign key self-referencing

### DIFF
--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -705,11 +705,11 @@ array `MUST` be a `foreignKey`. A `foreignKey` `MUST` be a `object` and `MUST` h
   field or fields on this resource that form the source part of the foreign
   key. The structure of the string or array is as per `primaryKey` above.
 - `reference` - `reference` `MUST` be a `object`. The `object`
+  - `MUST` have a property `resource` which is the name of the resource within the current data package, i.e. the data package within which this Table Schema is located. For referencing another data resource the corresponding `resource` property `MUST` be provided. For self-referencing, i.e. references between fields in this Table Schema, the `resource` property `MUST` be `self`.
   - `MUST` have a property `fields` which is a string if the outer `fields` is a
     string, else an array of the same length as the outer `fields`, describing the
     field (or fields) references on the destination resource. The structure of
     the string or array is as per `primaryKey` above.
-  - `MAY` have a property `resource` which is the name of the resource within the current data package, i.e. the data package within which this Table Schema is located. For referencing another data resource the `resource` property `MUST` be provided. For self-referencing, i.e. references between fields in this Table Schema, the `resource` property `MUST` be omitted.
 
 Here's an example:
 
@@ -752,7 +752,7 @@ An example of a self-referencing foreign key:
 ```javascript
   "resources": [
     {
-      "name": "xxx",
+      "name": "nested",
       "schema": {
         "fields": [
           {
@@ -766,7 +766,7 @@ An example of a self-referencing foreign key:
           {
             "fields": "parent"
             "reference": {
-              "resource": "",
+              "resource": "self",
               "fields": "id"
             }
           }
@@ -776,7 +776,11 @@ An example of a self-referencing foreign key:
   ]
 ```
 
-**Comment**: Foreign Keys create links between one Table Schema and another Table Schema, and implicitly between the data tables described by those Table Schemas. If the foreign key is referring to another Table Schema how is that other Table Schema discovered? The answer is that a Table Schema will usually be embedded inside some larger descriptor for a dataset, in particular as the schema for a resource in the resources array of a [Data Package][dp]. It is the use of Table Schema in this way that permits a meaningful use of a non-empty `resource` property on the foreign key.
+Foreign Keys create links between one Table Schema and another Table Schema, and implicitly between the data tables described by those Table Schemas. If the foreign key is referring to another Table Schema how is that other Table Schema discovered? The answer is that a Table Schema will usually be embedded inside some larger descriptor for a dataset, in particular as the schema for a resource in the resources array of a [Data Package][dp]. It is the use of Table Schema in this way that permits a meaningful use of a non-empty `resource` property on the foreign key.
+
+:::note[Backward Compatibility]
+If the value of the `foreignKey.reference.source` property is an empty string `""` a data consumer MUST interpret it as `self` as an empty string for self-referencing was a part of the `v1.0` of the specification.
+:::
 
 [dp]: http://specs.frictionlessdata.io/data-package/
 

--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -705,7 +705,7 @@ array `MUST` be a `foreignKey`. A `foreignKey` `MUST` be a `object` and `MUST` h
   field or fields on this resource that form the source part of the foreign
   key. The structure of the string or array is as per `primaryKey` above.
 - `reference` - `reference` `MUST` be a `object`. The `object`
-  - `MUST` have a property `resource` which is the name of the resource within the current data package, i.e. the data package within which this Table Schema is located. For referencing another data resource the corresponding `resource` property `MUST` be provided. For self-referencing, i.e. references between fields in this Table Schema, the `resource` property `MUST` be `self`.
+  - `MUST` have a property `resource` which is the name of the resource within the current data package, i.e. the data package within which this Table Schema is located. For self-referencing, i.e. references between fields in this Table Schema, the `resource` property `MUST` be `self`.
   - `MUST` have a property `fields` which is a string if the outer `fields` is a
     string, else an array of the same length as the outer `fields`, describing the
     field (or fields) references on the destination resource. The structure of

--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -647,15 +647,11 @@ array `MUST` be a `foreignKey`. A `foreignKey` `MUST` be a `object` and `MUST` h
   field or fields on this resource that form the source part of the foreign
   key. The structure of the string or array is as per `primaryKey` above.
 - `reference` - `reference` `MUST` be a `object`. The `object`
-  - `MUST` have a property `resource` which is the name of the resource within
-    the current data package (i.e. the data package within which this Table
-    Schema is located). For self-referencing foreign keys, i.e. references
-    between fields in this Table Schema, the value of `resource` `MUST` be `""`
-    (i.e. the empty string).
   - `MUST` have a property `fields` which is a string if the outer `fields` is a
     string, else an array of the same length as the outer `fields`, describing the
     field (or fields) references on the destination resource. The structure of
     the string or array is as per `primaryKey` above.
+  - `MAY` have a property `resource` which is the name of the resource within the current data package, i.e. the data package within which this Table Schema is located. Fore referencing another data resource the `resource` property `MUST` be provided. For self-referencing, i.e. references between fields in this Table Schema, the `resource` property `MUST` be omitted.
 
 Here's an example:
 

--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -709,7 +709,7 @@ array `MUST` be a `foreignKey`. A `foreignKey` `MUST` be a `object` and `MUST` h
     string, else an array of the same length as the outer `fields`, describing the
     field (or fields) references on the destination resource. The structure of
     the string or array is as per `primaryKey` above.
-  - `MAY` have a property `resource` which is the name of the resource within the current data package, i.e. the data package within which this Table Schema is located. Fore referencing another data resource the `resource` property `MUST` be provided. For self-referencing, i.e. references between fields in this Table Schema, the `resource` property `MUST` be omitted.
+  - `MAY` have a property `resource` which is the name of the resource within the current data package, i.e. the data package within which this Table Schema is located. For referencing another data resource the `resource` property `MUST` be provided. For self-referencing, i.e. references between fields in this Table Schema, the `resource` property `MUST` be omitted.
 
 Here's an example:
 

--- a/profiles/dictionary/schema.yaml
+++ b/profiles/dictionary/schema.yaml
@@ -160,12 +160,10 @@ tableSchemaForeignKey:
         reference:
           type: object
           required:
-            - resource
             - fields
           properties:
             resource:
               type: string
-              default: ""
             fields:
               type: array
               items:
@@ -179,12 +177,10 @@ tableSchemaForeignKey:
         reference:
           type: object
           required:
-            - resource
             - fields
           properties:
             resource:
               type: string
-              default: ""
             fields:
               type: string
 tableSchemaTrueValues:


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/878

---

# Rationale

Here is the list of other options:

- **empty string** - using `foreignKey.reference.resource: ""` for self-referencing. Honestly speaking, I think it's very confusing and error-prone. It's how it's currently implemented (v1)
- **omit** - omitting `foreignKey.reference.resource` for self-referencing. Rejected in #29
- **sql** - using `foreignKey.reference.resource: "<name>"` for self-referencing as in SQL DDL. It's a very eloquent option proposed [here](https://github.com/frictionlessdata/datapackage/pull/29#issuecomment-1938349860) but it [completely removes](https://github.com/frictionlessdata/datapackage/pull/29#issuecomment-1953118049) an ability to create shared Table Schemas that use self-referencing (can be very important for some projects)
- **self** - using `foreignKey.reference.resource: "self"` for self-referencing. Proposed in this PR. Not perfect but at least self-explanatory