### PR TITLE
Clarify english language for slugs

### DIFF
--- a/content/docs/specifications/data-package.md
+++ b/content/docs/specifications/data-package.md
@@ -128,7 +128,7 @@ If the `$schema` property is not provided but a descriptor has the `profile` pro
 
 The name is a simple name or identifier to be used for this package in relation to any registry in which this package will be deposited.
 
-- It `SHOULD` be human-readable and consist only of lowercase english alphanumeric characters plus `.`, `-` and `_`.
+- It `SHOULD` be human-readable and consist only of lowercase English alphanumeric characters plus `.`, `-` and `_`.
 - It `SHOULD` be unique in relation to any registry in which this package will be deposited (and preferably globally unique).
 - It `SHOULD` be invariant, meaning that it `SHOULD NOT` change when a data package is updated, unless the new package version `SHOULD` be considered a distinct package, e.g. due to significant changes in structure or interpretation. Version distinction `SHOULD` be left to the version property. As a corollary, the name also `SHOULD NOT` include an indication of time range covered.
 

--- a/content/docs/specifications/data-package.md
+++ b/content/docs/specifications/data-package.md
@@ -128,7 +128,7 @@ If the `$schema` property is not provided but a descriptor has the `profile` pro
 
 The name is a simple name or identifier to be used for this package in relation to any registry in which this package will be deposited.
 
-- It `SHOULD` be human-readable and consist only of lowercase alphanumeric characters plus ".", "-" and "\_".
+- It `SHOULD` be human-readable and consist only of lowercase english alphanumeric characters plus `.`, `-` and `_`.
 - It `SHOULD` be unique in relation to any registry in which this package will be deposited (and preferably globally unique).
 - It `SHOULD` be invariant, meaning that it `SHOULD NOT` change when a data package is updated, unless the new package version `SHOULD` be considered a distinct package, e.g. due to significant changes in structure or interpretation. Version distinction `SHOULD` be left to the version property. As a corollary, the name also `SHOULD NOT` include an indication of time range covered.
 

--- a/content/docs/specifications/data-resource.md
+++ b/content/docs/specifications/data-resource.md
@@ -57,7 +57,7 @@ The properties below are applicable to any Data Resource.
 A resource `MUST` contain a `name` property. The name is a simple name or identifier to be used for this resource.
 
 - It `MUST` be unique amongst all resources in this data package.
-- It `SHOULD` be human-readable and consist only of lowercase english alphanumeric characters plus `.`, `-` and `_`.
+- It `SHOULD` be human-readable and consist only of lowercase English alphanumeric characters plus `.`, `-` and `_`.
 - It would be usual for the name to correspond to the file name (minus the extension) of the data file the resource describes.
 
 #### `path` or `data` [required]

--- a/content/docs/specifications/data-resource.md
+++ b/content/docs/specifications/data-resource.md
@@ -57,7 +57,7 @@ The properties below are applicable to any Data Resource.
 A resource `MUST` contain a `name` property. The name is a simple name or identifier to be used for this resource.
 
 - It `MUST` be unique amongst all resources in this data package.
-- It `SHOULD` be human-readable and consist only of lowercase alphanumeric characters plus `.`, `-` and `\_`.
+- It `SHOULD` be human-readable and consist only of lowercase english alphanumeric characters plus `.`, `-` and `_`.
 - It would be usual for the name to correspond to the file name (minus the extension) of the data file the resource describes.
 
 #### `path` or `data` [required]


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/specs/issues/449

---

It's never been explicitly written but slugs were always intended to be in English (see v1 regexp)