### PR TITLE
Update structure for Table Schema

### DIFF
--- a/content/docs/standard/changelog.md
+++ b/content/docs/standard/changelog.md
@@ -14,87 +14,123 @@ This document includes all meaningful changes made to the **specifications** con
 
 The Data Package (v2) draft release includes a rich set of the specification improvements accepted by the Data Package Working Group during the active phase of the Data Package (v2) work.
 
-### Changes
+### Specifications
 
-#### Specifications
-
-##### Added `source.version` property
+#### Added `source.version` property
 
 This change adds a new property to make possible of providing information about source version. Please read more about [`source.version`](../../specifications/data-package/#sources) property.
 
 > [Pull Request -- #10](https://github.com/frictionlessdata/datapackage/pull/10)
 
-##### Made `contributor/source.title` not required
+#### Made `contributor/source.title` not required
 
 This change allows omitting `title` property for the `contributor` and `source` objects making it more flexible for data producers.
 
 > [Pull Request -- #7](https://github.com/frictionlessdata/datapackage/pull/7)
 
-#### Data Package
+### Data Package
 
-##### Added `contributor.given/familyName`
+#### Added `contributor.given/familyName`
 
 This change adds two new properties to the `contributor` object: `givenName` and `familyName`. Please read more about [`package.contributors`](../../specifications/data-package/#contributors) property.
 
 > [Pull Request -- #20](https://github.com/frictionlessdata/datapackage/pull/20)
 
-##### Added `contributor.roles` property
+#### Added `contributor.roles` property
 
 This change adds a new `contributors.roles` property that replaces `contributor.role`. Please read more about [`package.contributors`](../../specifications/data-package/#contributors) property.
 
 > [Pull Request -- #18](https://github.com/frictionlessdata/datapackage/pull/18)
 
-##### Fixed `version` property in Data Package profile
+#### Fixed `version` property in Data Package profile
 
 This change adds omitted `version` property to the Data Package profiles.
 
 > [Pull Request -- #3](https://github.com/frictionlessdata/datapackage/pull/3)
 
-#### Data Resource
+### Data Resource
 
-##### Relaxed `resource.name` rules but keep it required and unique
+#### Relaxed `resource.name` rules but keep it required and unique
 
 This change relaxes requirements to `resource.name` allowing it to be any string. This property still needs to present and be unique among resources. Please read more about [`resource.name`](../../specifications/data-resource/#name-required) property.
 
 > [Pull Request -- #27](https://github.com/frictionlessdata/datapackage/pull/27)
 
-##### Clarified `resource.encoding` property
+#### Clarified `resource.encoding` property
 
 This change updates the `resource.encoding` property definition to properly support binary file formats like Parquet. Please read more about [`resource.encoding`](../../specifications/data-resource/#encoding) property.
 
 > [Pull Request -- #15](https://github.com/frictionlessdata/datapackage/pull/15)
 
-##### Forbade hidden folders in paths
+#### Forbade hidden folders in paths
 
 This change fixes definition in the Data Resource specification to explicitly forbid hidden folders.
 
 > [Pull Request -- #19](https://github.com/frictionlessdata/datapackage/pull/19)
 
-#### Table Dialect
+### Table Dialect
 
-##### First version of the specification
+#### First version of the specification
 
 This change adds a new specification Table Dialect that superseeds and extends the CSV Dialect specification to work with other formats like JSON or Excel. Please refer to the [Table Dialect](../../specifications/table-dialect) specification.
 
 > [Pull Request -- #41](https://github.com/frictionlessdata/datapackage/pull/41)
 
-#### Table Schema
+### Table Schema
 
-- New [`fieldsMatch`](../../specifications/table-schema/#fieldsmatch) property: clarifies the default field matching behaviour between Table Schema and data source fields (i.e. all fields are defined and in the same order) and adds new modes for matching fields ([#39](https://github.com/frictionlessdata/datapackage/pull/39)).
-- New [`uniqueKeys`](../../specifications/table-schema/#uniquekeys) property: allows to specify which fields are required to have unique logical values. It is an alternative to the `field.contraints.unique` property and is modelled after the corresponding SQL feature ([#30](https://github.com/frictionlessdata/datapackage/pull/30)).
-- Updated [`primaryKey`](../../specifications/table-schema/#primarykey): should now always be an array ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
-- Updated [`foreignKeys`](../../specifications/table-schema/#foreignkeys): should now always be an array ([#28](https://github.com/frictionlessdata/datapackage/pull/28)). `foreignKey.resource.reference` can now be omitted in case of self-referencing. Previously it required setting resource to an empty string ([#29](https://github.com/frictionlessdata/datapackage/pull/29).
-- New [`missingValues`](../../specifications/table-schema/#missingvalues) field property: allows to specify missing values per field (in addition to `missingValues` at a resource level) ([#24](https://github.com/frictionlessdata/datapackage/pull/24)).
-- Updated [`datetime`](../../specifications/table-schema/#datetime) field type: the default `format` for `datetime` is now extended to allow optional milliseconds and timezone parts ([#23](https://github.com/frictionlessdata/datapackage/pull/23)).
-- Updated [`geopoint`](../../specifications/table-schema/#geopoint) field type: the definition now clarifies that floating point numbers can be used for coordinate definitions ([#14](https://github.com/frictionlessdata/datapackage/pull/14)).
-- Updated [`any`](../../specifications/table-schema/#any) field type: `any` is now the default field type and ensures that the field type is not inferred if not provided ([#13](https://github.com/frictionlessdata/datapackage/pull/13)).
-- New [`list`](../../specifications/table-schema/#list) field type: allows to specify collections of primary values collections, separated by a delimiter (e.g. `value1,value`) ([#38](https://github.com/frictionlessdata/datapackage/pull/38)).
-- Updated [`minimum`](../../specifications/table-schema/#minimum) and [`maximum`](../../specifications/table-schema/#maximum) constraints: these constraints now support the `duration` field type ([#8](https://github.com/frictionlessdata/datapackage/pull/8).
-- New [`jsonSchema`](../../specifications/table-schema/#jsonschema) field constraint: can be used for `object` and `array` fields ([#32](https://github.com/frictionlessdata/datapackage/pull/32)).
-- New [`exclusiveMinimum`](../../specifications/table-schema/#exclusiveminimum) and [`exclusiveMaximum`](../../specifications/table-schema/#exclusivemaximum) field contraints ([#11](https://github.com/frictionlessdata/datapackage/pull/11)).
-- New [`groupChar`](../../specifications/table-schema/#integer) integer property: supports group characters for integers. It was already available for numbers ([#6](https://github.com/frictionlessdata/datapackage/pull/6)).
+#### Updated property `primaryKey`
 
-> [Pull Request -- 
+[`primaryKey`](../../specifications/table-schema/#primarykey) should now always be an array of strings, not a string. ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
+
+#### Updated property `foreignKeys`
+
+[`foreignKeys`](../../specifications/table-schema/#foreignkeys) should now always be an array of strings, not a string ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
+
+`foreignKey.resource.reference` can now be omitted for self-referencing foreign keys. Previously it required setting resource to an empty string ([#29](https://github.com/frictionlessdata/datapackage/pull/29).
+
+#### New property `fieldsMatch`
+
+[fieldsMatch](../../specifications/table-schema/#fieldsmatch) clarifies the default field matching behaviour between Table Schema and data source fields (i.e. all fields are defined and in the same order) and adds new modes for matching fields ([#39](https://github.com/frictionlessdata/datapackage/pull/39)).
+
+#### New property `uniqueKeys`
+
+[`uniqueKeys`](../../specifications/table-schema/#uniquekeys) allows to specify which fields are required to have unique logical values. It is an alternative to the `field.contraints.unique` property and is modelled after the corresponding SQL feature ([#30](https://github.com/frictionlessdata/datapackage/pull/30)).
+
+#### New field property `missingValues`
+
+[`missingValues`](../../specifications/table-schema/#missingvalues) allows to specify missing values per field, and overwrites `missingValues` specifified at a resource level ([#24](https://github.com/frictionlessdata/datapackage/pull/24)).
+
+#### Updated field type `datetime`
+
+The default `format` for [`datetime`](../../specifications/table-schema/#datetime) is now extended to allow optional milliseconds and timezone parts ([#23](https://github.com/frictionlessdata/datapackage/pull/23)).
+
+#### Updated field type `geopoint`
+
+The definition for [`geopoint`](../../specifications/table-schema/#geopoint) now clarifies that floating point numbers can be used for coordinate definitions ([#14](https://github.com/frictionlessdata/datapackage/pull/14)).
+
+#### Updated field type `any`
+
+[`any`](../../specifications/table-schema/#any) is now the default field type and ensures that the field type is not inferred if not provided ([#13](https://github.com/frictionlessdata/datapackage/pull/13)).
+
+#### New field type `list`
+
+[`list`](../../specifications/table-schema/#list) allows to specify fields containing collections of primary values, separated by a delimiter (e.g. `value1,value`) ([#38](https://github.com/frictionlessdata/datapackage/pull/38)).
+
+#### Updated constraints `minimum` and `maximum`
+
+[`minimum`](../../specifications/table-schema/#minimum) and [`maximum`](../../specifications/table-schema/#maximum) are now extended to support the `duration` field type ([#8](https://github.com/frictionlessdata/datapackage/pull/8).
+
+#### New constraint `jsonschema`
+
+[`jsonSchema`](../../specifications/table-schema/#jsonschema) can be used for the `object` and `array` field types ([#32](https://github.com/frictionlessdata/datapackage/pull/32)).
+
+#### New constraints `exclusiveMinimum` and `exclusiveMaximum`
+
+[`exclusiveMinimum`](../../specifications/table-schema/#exclusiveminimum) and [`exclusiveMaximum`](../../specifications/table-schema/#exclusivemaximum) can be used to specify exclusive minimum and maximum contraints ([#11](https://github.com/frictionlessdata/datapackage/pull/11)).
+
+#### New integer property `groupChar`
+
+[`groupChar`](../../specifications/table-schema/#integer) can now be used for the `integer` field type. It was already available for `number` ([#6](https://github.com/frictionlessdata/datapackage/pull/6)).
 
 ## v1.0
 

--- a/content/docs/standard/changelog.md
+++ b/content/docs/standard/changelog.md
@@ -80,83 +80,21 @@ This change adds a new specification Table Dialect that superseeds and extends t
 
 #### Table Schema
 
-##### Added `schema.fieldsMatch` property
+- New [`fieldsMatch`](../../specifications/table-schema/#fieldsmatch) property: clarifies the default field matching behaviour between Table Schema and data source fields (i.e. all fields are defined and in the same order) and adds new modes for matching fields ([#39](https://github.com/frictionlessdata/datapackage/pull/39)).
+- New [`uniqueKeys`](../../specifications/table-schema/#uniquekeys) property: allows to specify which fields are required to have unique logical values. It is an alternative to the `field.contraints.unique` property and is modelled after the corresponding SQL feature ([#30](https://github.com/frictionlessdata/datapackage/pull/30)).
+- Updated [`primaryKey`](../../specifications/table-schema/#primarykey): should now always be an array ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
+- Updated [`foreignKeys`](../../specifications/table-schema/#foreignkeys): should now always be an array ([#28](https://github.com/frictionlessdata/datapackage/pull/28)). `foreignKey.resource.reference` can now be omitted in case of self-referencing. Previously it required setting resource to an empty string ([#29](https://github.com/frictionlessdata/datapackage/pull/29).
+- New [`missingValues`](../../specifications/table-schema/#missingvalues) field property: allows to specify missing values per field (in addition to `missingValues` at a resource level) ([#24](https://github.com/frictionlessdata/datapackage/pull/24)).
+- Updated [`datetime`](../../specifications/table-schema/#datetime) field type: the default `format` for `datetime` is now extended to allow optional milliseconds and timezone parts ([#23](https://github.com/frictionlessdata/datapackage/pull/23)).
+- Updated [`geopoint`](../../specifications/table-schema/#geopoint) field type: the definition now clarifies that floating point numbers can be used for coordinate definitions ([#14](https://github.com/frictionlessdata/datapackage/pull/14)).
+- Updated [`any`](../../specifications/table-schema/#any) field type: `any` is now the default field type and ensures that the field type is not inferred if not provided ([#13](https://github.com/frictionlessdata/datapackage/pull/13)).
+- New [`list`](../../specifications/table-schema/#list) field type: allows to specify collections of primary values collections, separated by a delimiter (e.g. `value1,value`) ([#38](https://github.com/frictionlessdata/datapackage/pull/38)).
+- Updated [`minimum`](../../specifications/table-schema/#minimum) and [`maximum`](../../specifications/table-schema/#maximum) constraints: these constraints now support the `duration` field type ([#8](https://github.com/frictionlessdata/datapackage/pull/8).
+- New [`jsonSchema`](../../specifications/table-schema/#jsonschema) field constraint: can be used for `object` and `array` fields ([#32](https://github.com/frictionlessdata/datapackage/pull/32)).
+- New [`exclusiveMinimum`](../../specifications/table-schema/#exclusiveminimum) and [`exclusiveMaximum`](../../specifications/table-schema/#exclusivemaximum) field contraints ([#11](https://github.com/frictionlessdata/datapackage/pull/11)).
+- New [`groupChar`](../../specifications/table-schema/#integer) integer property: supports group characters for integers. It was already available for numbers ([#6](https://github.com/frictionlessdata/datapackage/pull/6)).
 
-This change clarifies the default field matching behaviour and adds new modes for matching data source and Table Schema fields. Please read more about [`schema.fieldsMatch`](../../specifications/table-schema/#fieldsmatch) property.
-
-> [Pull Request -- #39](https://github.com/frictionlessdata/datapackage/pull/39)
-
-##### Made `any` be a default field type
-
-This change makes field type to be `any` by default and ensures that the field type is not inferred if not provided. Please read more about [`any`](../../specifications/table-schema/#any) type.
-
-> [Pull Request -- #13](https://github.com/frictionlessdata/datapackage/pull/13)
-
-##### Added `uniqueKeys` property
-
-This change adds `uniqueKeys` property directly modelled after corresponding SQL feature. Please read more about [`schema.uniqueKeys`](../../specifications/table-schema/#uniquekeys) property.
-
-> [Pull Request -- #30](https://github.com/frictionlessdata/datapackage/pull/30)
-
-##### Added `field.missingValues`
-
-This change adds a property that allows to specify missing values individually per field. Please read more about [`field.missingValues`](../../specifications/table-schema/#missingvalues) property.
-
-> [Pull Request -- #24](https://github.com/frictionlessdata/datapackage/pull/24)
-
-##### Added `list` field type
-
-This change adds a new field type `list` for typed collections, lexically delimiter-based. Please read more about [`list`](../../specifications/table-schema/#list) type.
-
-> [Pull Request -- #38](https://github.com/frictionlessdata/datapackage/pull/38)
-
-##### Added `jsonSchema` constraint to object and array fields
-
-This change adds a new constraint for the `object` and `array` fields. Please read more about [`constraints.jsonSchema`](../../specifications/table-schema/#jsonschema) constraint.
-
-> [Pull Request -- #32](https://github.com/frictionlessdata/datapackage/pull/32)
-
-##### Support `groupChar` for integer field type
-
-This change adds support for providing integers with group chars. Please read more about [`field.groupChar`](../../specifications/table-schema/#integer) property.
-
-> [Pull Request -- #6](https://github.com/frictionlessdata/datapackage/pull/6)
-
-##### Extended `datetime` default format
-
-This change extends `default` format definition for the `datetime` field type allowing to provide optional milliseconds and timezone parts.
-
-> [Pull Request -- #23](https://github.com/frictionlessdata/datapackage/pull/23)
-
-##### Supported exclusive constraints
-
-This change adds new `exclusiveMinimum` and `exclusiveMaximum` constraints to the Table Schema specification.
-
-> [Pull Request -- #11](https://github.com/frictionlessdata/datapackage/pull/11)
-
-##### Simplified self-referencing in foreign keys
-
-This change allows omitting `foreignKey.resource.reference` in case of self-referencing. Previously it required setting resource to an empty string.
-
-> [Pull Request -- #29](https://github.com/frictionlessdata/datapackage/pull/29)
-
-##### Discouraged usage of unnecessary union types
-
-This change discourages usage of mixed types for `schema.primaryKeys` and `schema.foreignKeys.fields` properties.
-
-> [Pull Request -- #28](https://github.com/frictionlessdata/datapackage/pull/28)
-
-##### Clarified that `geopoint` is number-based
-
-This changes clarifies that `geopoint` field type can use floating point numbers for coordinate definitions.
-
-> [Pull Request -- #14](https://github.com/frictionlessdata/datapackage/pull/14)
-
-##### Fixed duration constraint
-
-This change fixes `minimum` and `maximum` constraint for the `duration` field type.
-
-> [Pull Request -- #8](https://github.com/frictionlessdata/datapackage/pull/8)
+> [Pull Request -- 
 
 ## v1.0
 


### PR DESCRIPTION
This is a PR in response to @roll's comment at https://github.com/frictionlessdata/datapackage/pull/45#issuecomment-2027303895

I've tried to reduce the repetition in the descriptions of the CHANGELOG (currently for the Table Schema section only). I have left one heading per change. Curious how it looks like when rendered. 😄 