### PR TITLE
Reorganized CHANGELOG

### DIFF
--- a/content/docs/recipes/relationship-between-fields.md
+++ b/content/docs/recipes/relationship-between-fields.md
@@ -5,7 +5,7 @@ title: Relationship between Fields
 <table>
   <tr>
     <th>Authors</th>
-    <td>Philippe THOMY, Peter Desmet</td>
+    <td>Philippe Thomy, Peter Desmet</td>
   </tr>
 </table>
 

--- a/content/docs/specifications/data-package.md
+++ b/content/docs/specifications/data-package.md
@@ -19,7 +19,7 @@ A simple container format for describing a coherent collection of data in a sing
 
 ## Language
 
-The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt)
+The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 ## Introduction
 

--- a/content/docs/specifications/data-package.md
+++ b/content/docs/specifications/data-package.md
@@ -221,8 +221,8 @@ An Array of string keywords to assist users searching for the package in catalog
 The people or organizations who contributed to this Data Package. It `MUST` be an array. Each entry is a Contributor and `MUST` be an `object`. A Contributor `MUST` have at least one property. A Contributor is `RECOMMENDED` to have `title` property and `MAY` contain `givenName`, `familyName`, `path`, `email`, `roles`, and `organization` properties:
 
 - `title`: A string containing a name of the contributor.
-- `givenName`: A string containing name a person has been given, if the contributor is a person.
-- `familyName`: A string containing familial name that a person inherits, if the contributor is a person.
+- `givenName`: A string containing the name a person has been given, if the contributor is a person.
+- `familyName`: A string containing the familial name that a person inherits, if the contributor is a person.
 - `path`: A fully qualified URL pointing to a relevant location online for the contributor.
 - `email`: A string containing an email address.
 - `roles`: An array of strings describing the roles of the contributor. A role is `RECOMMENDED` to follow an established vocabulary, such as [DataCite Metadata Schema's contributorRole](https://support.datacite.org/docs/datacite-metadata-schema-v44-recommended-and-optional-properties#7a-contributortype) or [CreDIT](https://credit.niso.org/). Useful roles to indicate are: `creator`, `contact`, `rightsHolder`, and `dataCurator`.

--- a/content/docs/specifications/data-resource.md
+++ b/content/docs/specifications/data-resource.md
@@ -19,7 +19,7 @@ A simple format to describe and package a single data resource such as a individ
 
 ## Language
 
-The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt)
+The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 ## Descriptor
 

--- a/content/docs/specifications/extensions.md
+++ b/content/docs/specifications/extensions.md
@@ -15,7 +15,7 @@ The Data Package Standard extensibility features for domain-specific needs.
 
 ## Language
 
-The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt)
+The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 ## Introduction
 

--- a/content/docs/specifications/glossary.md
+++ b/content/docs/specifications/glossary.md
@@ -74,7 +74,7 @@ A `URL or Path` is a `string` with the following additional constraints:
 
 - `MUST` either be a URL or a POSIX path
 - [URLs](https://en.wikipedia.org/wiki/Uniform_Resource_Locator) `MUST` be fully qualified. `MUST` be using either http or https scheme. (Absence of a scheme indicates `MUST` be a POSIX path)
-- [POSIX paths](https://en.wikipedia.org/wiki/Path_%28computing%29#POSIX_pathname_definition) (unix-style with `/` as separator) are supported for referencing local files, with the security restraint that they `MUST` be relative siblings or children of the descriptor. Absolute paths `/`, relative parent paths `../`, hidden folders starting from a dot `.hidden` `MUST` NOT be used.
+- [POSIX paths](https://en.wikipedia.org/wiki/Path_%28computing%29#POSIX_pathname_definition) (unix-style with `/` as separator) are supported for referencing local files, with the security restraint that they `MUST` be relative siblings or children of the descriptor. Absolute paths `/`, relative parent paths `../`, hidden folders starting from a dot `.hidden` `MUST NOT` be used.
 
 Example of a fully qualified url:
 

--- a/content/docs/specifications/glossary.md
+++ b/content/docs/specifications/glossary.md
@@ -15,7 +15,7 @@ A dictionary of special terms for the Data Package Standard.
 
 ## Language
 
-The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt)
+The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 ## Definitions
 

--- a/content/docs/specifications/security.md
+++ b/content/docs/specifications/security.md
@@ -15,7 +15,7 @@ Security considerations around Data Packages and Data Resources.
 
 ## Language
 
-The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt)
+The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 ## Usage Perspective
 

--- a/content/docs/specifications/table-dialect.md
+++ b/content/docs/specifications/table-dialect.md
@@ -19,7 +19,7 @@ Table Dialect describes how tabular data is stored in a file. It supports delimi
 
 ## Language
 
-The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt)
+The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 ## Introduction
 

--- a/content/docs/specifications/table-schema.md
+++ b/content/docs/specifications/table-schema.md
@@ -19,7 +19,7 @@ A simple format to declare a schema for tabular data. The schema is designed to 
 
 ## Language
 
-The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt)
+The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
 ## Introduction
 

--- a/content/docs/standard/changelog.md
+++ b/content/docs/standard/changelog.md
@@ -14,87 +14,123 @@ This document includes all meaningful changes made to the **specifications** con
 
 The Data Package (v2) draft release includes a rich set of the specification improvements accepted by the Data Package Working Group during the active phase of the Data Package (v2) work.
 
-### Changes
+### Specifications
 
-#### Specifications
-
-##### Added `source.version` property
+#### Added `source.version` property
 
 This change adds a new property to make possible of providing information about source version. Please read more about [`source.version`](../../specifications/data-package/#sources) property.
 
 > [Pull Request -- #10](https://github.com/frictionlessdata/datapackage/pull/10)
 
-##### Made `contributor/source.title` not required
+#### Made `contributor/source.title` not required
 
 This change allows omitting `title` property for the `contributor` and `source` objects making it more flexible for data producers.
 
 > [Pull Request -- #7](https://github.com/frictionlessdata/datapackage/pull/7)
 
-#### Data Package
+### Data Package
 
-##### Added `contributor.given/familyName`
+#### Added `contributor.given/familyName`
 
 This change adds two new properties to the `contributor` object: `givenName` and `familyName`. Please read more about [`package.contributors`](../../specifications/data-package/#contributors) property.
 
 > [Pull Request -- #20](https://github.com/frictionlessdata/datapackage/pull/20)
 
-##### Added `contributor.roles` property
+#### Added `contributor.roles` property
 
 This change adds a new `contributors.roles` property that replaces `contributor.role`. Please read more about [`package.contributors`](../../specifications/data-package/#contributors) property.
 
 > [Pull Request -- #18](https://github.com/frictionlessdata/datapackage/pull/18)
 
-##### Fixed `version` property in Data Package profile
+#### Fixed `version` property in Data Package profile
 
 This change adds omitted `version` property to the Data Package profiles.
 
 > [Pull Request -- #3](https://github.com/frictionlessdata/datapackage/pull/3)
 
-#### Data Resource
+### Data Resource
 
-##### Relaxed `resource.name` rules but keep it required and unique
+#### Relaxed `resource.name` rules but keep it required and unique
 
 This change relaxes requirements to `resource.name` allowing it to be any string. This property still needs to present and be unique among resources. Please read more about [`resource.name`](../../specifications/data-resource/#name-required) property.
 
 > [Pull Request -- #27](https://github.com/frictionlessdata/datapackage/pull/27)
 
-##### Clarified `resource.encoding` property
+#### Clarified `resource.encoding` property
 
 This change updates the `resource.encoding` property definition to properly support binary file formats like Parquet. Please read more about [`resource.encoding`](../../specifications/data-resource/#encoding) property.
 
 > [Pull Request -- #15](https://github.com/frictionlessdata/datapackage/pull/15)
 
-##### Forbade hidden folders in paths
+#### Forbade hidden folders in paths
 
 This change fixes definition in the Data Resource specification to explicitly forbid hidden folders.
 
 > [Pull Request -- #19](https://github.com/frictionlessdata/datapackage/pull/19)
 
-#### Table Dialect
+### Table Dialect
 
-##### First version of the specification
+#### First version of the specification
 
 This change adds a new specification Table Dialect that superseeds and extends the CSV Dialect specification to work with other formats like JSON or Excel. Please refer to the [Table Dialect](../../specifications/table-dialect) specification.
 
 > [Pull Request -- #41](https://github.com/frictionlessdata/datapackage/pull/41)
 
-#### Table Schema
+### Table Schema
 
-- New [`fieldsMatch`](../../specifications/table-schema/#fieldsmatch) property: clarifies the default field matching behaviour between Table Schema and data source fields (i.e. all fields are defined and in the same order) and adds new modes for matching fields ([#39](https://github.com/frictionlessdata/datapackage/pull/39)).
-- New [`uniqueKeys`](../../specifications/table-schema/#uniquekeys) property: allows to specify which fields are required to have unique logical values. It is an alternative to the `field.contraints.unique` property and is modelled after the corresponding SQL feature ([#30](https://github.com/frictionlessdata/datapackage/pull/30)).
-- Updated [`primaryKey`](../../specifications/table-schema/#primarykey): should now always be an array ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
-- Updated [`foreignKeys`](../../specifications/table-schema/#foreignkeys): should now always be an array ([#28](https://github.com/frictionlessdata/datapackage/pull/28)). `foreignKey.resource.reference` can now be omitted in case of self-referencing. Previously it required setting resource to an empty string ([#29](https://github.com/frictionlessdata/datapackage/pull/29).
-- New [`missingValues`](../../specifications/table-schema/#missingvalues) field property: allows to specify missing values per field (in addition to `missingValues` at a resource level) ([#24](https://github.com/frictionlessdata/datapackage/pull/24)).
-- Updated [`datetime`](../../specifications/table-schema/#datetime) field type: the default `format` for `datetime` is now extended to allow optional milliseconds and timezone parts ([#23](https://github.com/frictionlessdata/datapackage/pull/23)).
-- Updated [`geopoint`](../../specifications/table-schema/#geopoint) field type: the definition now clarifies that floating point numbers can be used for coordinate definitions ([#14](https://github.com/frictionlessdata/datapackage/pull/14)).
-- Updated [`any`](../../specifications/table-schema/#any) field type: `any` is now the default field type and ensures that the field type is not inferred if not provided ([#13](https://github.com/frictionlessdata/datapackage/pull/13)).
-- New [`list`](../../specifications/table-schema/#list) field type: allows to specify collections of primary values collections, separated by a delimiter (e.g. `value1,value`) ([#38](https://github.com/frictionlessdata/datapackage/pull/38)).
-- Updated [`minimum`](../../specifications/table-schema/#minimum) and [`maximum`](../../specifications/table-schema/#maximum) constraints: these constraints now support the `duration` field type ([#8](https://github.com/frictionlessdata/datapackage/pull/8).
-- New [`jsonSchema`](../../specifications/table-schema/#jsonschema) field constraint: can be used for `object` and `array` fields ([#32](https://github.com/frictionlessdata/datapackage/pull/32)).
-- New [`exclusiveMinimum`](../../specifications/table-schema/#exclusiveminimum) and [`exclusiveMaximum`](../../specifications/table-schema/#exclusivemaximum) field contraints ([#11](https://github.com/frictionlessdata/datapackage/pull/11)).
-- New [`groupChar`](../../specifications/table-schema/#integer) integer property: supports group characters for integers. It was already available for numbers ([#6](https://github.com/frictionlessdata/datapackage/pull/6)).
+#### Updated property `primaryKey`
 
-> [Pull Request -- 
+[`primaryKey`](../../specifications/table-schema/#primarykey) should now always be an array of strings, not a string. ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
+
+#### Updated property `foreignKeys`
+
+[`foreignKeys`](../../specifications/table-schema/#foreignkeys) should now always be an array of strings, not a string ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
+
+`foreignKey.resource.reference` can now be omitted for self-referencing foreign keys. Previously it required setting resource to an empty string ([#29](https://github.com/frictionlessdata/datapackage/pull/29).
+
+#### New property `fieldsMatch`
+
+[fieldsMatch](../../specifications/table-schema/#fieldsmatch) clarifies the default field matching behaviour between Table Schema and data source fields (i.e. all fields are defined and in the same order) and adds new modes for matching fields ([#39](https://github.com/frictionlessdata/datapackage/pull/39)).
+
+#### New property `uniqueKeys`
+
+[`uniqueKeys`](../../specifications/table-schema/#uniquekeys) allows to specify which fields are required to have unique logical values. It is an alternative to the `field.contraints.unique` property and is modelled after the corresponding SQL feature ([#30](https://github.com/frictionlessdata/datapackage/pull/30)).
+
+#### New field property `missingValues`
+
+[`missingValues`](../../specifications/table-schema/#missingvalues) allows to specify missing values per field, and overwrites `missingValues` specifified at a resource level ([#24](https://github.com/frictionlessdata/datapackage/pull/24)).
+
+#### Updated field type `datetime`
+
+The default `format` for [`datetime`](../../specifications/table-schema/#datetime) is now extended to allow optional milliseconds and timezone parts ([#23](https://github.com/frictionlessdata/datapackage/pull/23)).
+
+#### Updated field type `geopoint`
+
+The definition for [`geopoint`](../../specifications/table-schema/#geopoint) now clarifies that floating point numbers can be used for coordinate definitions ([#14](https://github.com/frictionlessdata/datapackage/pull/14)).
+
+#### Updated field type `any`
+
+[`any`](../../specifications/table-schema/#any) is now the default field type and ensures that the field type is not inferred if not provided ([#13](https://github.com/frictionlessdata/datapackage/pull/13)).
+
+#### New field type `list`
+
+[`list`](../../specifications/table-schema/#list) allows to specify fields containing collections of primary values, separated by a delimiter (e.g. `value1,value`) ([#38](https://github.com/frictionlessdata/datapackage/pull/38)).
+
+#### Updated constraints `minimum` and `maximum`
+
+[`minimum`](../../specifications/table-schema/#minimum) and [`maximum`](../../specifications/table-schema/#maximum) are now extended to support the `duration` field type ([#8](https://github.com/frictionlessdata/datapackage/pull/8).
+
+#### New constraint `jsonschema`
+
+[`jsonSchema`](../../specifications/table-schema/#jsonschema) can be used for the `object` and `array` field types ([#32](https://github.com/frictionlessdata/datapackage/pull/32)).
+
+#### New constraints `exclusiveMinimum` and `exclusiveMaximum`
+
+[`exclusiveMinimum`](../../specifications/table-schema/#exclusiveminimum) and [`exclusiveMaximum`](../../specifications/table-schema/#exclusivemaximum) can be used to specify exclusive minimum and maximum contraints ([#11](https://github.com/frictionlessdata/datapackage/pull/11)).
+
+#### New integer property `groupChar`
+
+[`groupChar`](../../specifications/table-schema/#integer) can now be used for the `integer` field type. It was already available for `number` ([#6](https://github.com/frictionlessdata/datapackage/pull/6)).
 
 ## v1.0
 

--- a/content/docs/standard/changelog.md
+++ b/content/docs/standard/changelog.md
@@ -4,7 +4,7 @@ sidebar:
   order: 10
 ---
 
-This document includes all meaningful changes made to the **specifications** consisting the Data Package Standard. It does not track changes made to other documents like recipes or guides.
+This document includes all meaningful changes made to the Data Package Standard **specifications**. It does not cover changes made to other documents like recipes or guides.
 
 ## v2.0-draft
 
@@ -24,14 +24,6 @@ The Data Package (v2) draft release includes a rich set of the specification imp
 
 [`contributor.title`](../../specifications/data-package/#contributors) is no longer required ([#7](https://github.com/frictionlessdata/datapackage/pull/7)).
 
-##### Deprecated property `contributor.role`
-
-`contributor.role` has been deprecated in favour of `contributor.roles`, see further ([#18](https://github.com/frictionlessdata/datapackage/pull/18)).
-
-##### Updated property `source.title`
-
-[`source.title`](../../specifications/data-package/#sources) is no longer required ([#7](https://github.com/frictionlessdata/datapackage/pull/7)).
-
 ##### New properties `contributor.givenName` and `contributor.familyName`
 
 [`contributor.givenName`](../../specifications/data-package/#contributors) and [`contributor.familyName`](../../specifications/data-package/#contributors) can be used to specify the given and family name of contributor, if it is a person ([#20](https://github.com/frictionlessdata/datapackage/pull/20)).
@@ -39,6 +31,14 @@ The Data Package (v2) draft release includes a rich set of the specification imp
 ##### New property `contributor.roles`
 
 [`contributor.roles`](../../specifications/data-package/#contributors) allows to specify multiple roles per contributor, rather than having to duplicate the contributor. Other changes from the now deprecated `role` are that it recommendeds to follow an established vocabulary and has new suggested values ([#18](https://github.com/frictionlessdata/datapackage/pull/18)).
+
+##### Deprecated property `contributor.role`
+
+`contributor.role` has been deprecated in favour of `contributor.roles`, see above ([#18](https://github.com/frictionlessdata/datapackage/pull/18)).
+
+##### Updated property `source.title`
+
+[`source.title`](../../specifications/data-package/#sources) is no longer required ([#7](https://github.com/frictionlessdata/datapackage/pull/7)).
 
 ##### New property `source.version`
 
@@ -50,13 +50,13 @@ The Data Package (v2) draft release includes a rich set of the specification imp
 
 [name](../../specifications/data-resource/#name-required) now allows any string. It previously required the name to only consist of lowercase alphanumeric characters plus `.`, `-` and `_`. The property is still required and must be unique among resources ([#27](https://github.com/frictionlessdata/datapackage/pull/27)).
 
-##### Updated property `encoding`
-
-[encoding](../../specifications/data-resource/#encoding)'s definition has been updated to support binary formats like Parquet ([#15](https://github.com/frictionlessdata/datapackage/pull/15)).
-
 ##### Updated property `path`
 
 [path](../../specifications/data-resource/#path-or-data-required) now explicitely forbids hidden folders (starting with dot `.`) ([#19](https://github.com/frictionlessdata/datapackage/pull/19)).
+
+##### Updated property `encoding`
+
+[encoding](../../specifications/data-resource/#encoding)'s definition has been updated to support binary formats like Parquet ([#15](https://github.com/frictionlessdata/datapackage/pull/15)).
 
 ### Table Dialect
 
@@ -64,9 +64,19 @@ The Data Package (v2) draft release includes a rich set of the specification imp
 
 ### Table Schema
 
+#### Schema
+
+##### New property `fieldsMatch`
+
+[fieldsMatch](../../specifications/table-schema/#fieldsmatch) allows to specify how fields in a Table Schema match the fields in the data source. The default (`exact`) matches the Data Package v1 behaviour, but other values (e.g. `subset`, `superset`) allow to define fewer or more fields and match on field names. This new property extends and makes explicit the `schema_sync` option in Frictionless Framework ([#39](https://github.com/frictionlessdata/datapackage/pull/39)).
+
 ##### Updated property `primaryKey`
 
 [`primaryKey`](../../specifications/table-schema/#primarykey) should now always be an array of strings, not a string ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
+
+##### New property `uniqueKeys`
+
+[`uniqueKeys`](../../specifications/table-schema/#uniquekeys) allows to specify which fields are required to have unique logical values. It is an alternative to `field.contraints.unique` and is modelled after the corresponding SQL feature ([#30](https://github.com/frictionlessdata/datapackage/pull/30)).
 
 ##### Updated property `foreignKeys`
 
@@ -74,17 +84,19 @@ The Data Package (v2) draft release includes a rich set of the specification imp
 
 `foreignKeys.reference.resource` can now be omitted for self-referencing foreign keys. Previously it required setting resource to an empty string ([#29](https://github.com/frictionlessdata/datapackage/pull/29)).
 
-##### New property `fieldsMatch`
-
-[fieldsMatch](../../specifications/table-schema/#fieldsmatch) allows to specify how fields in a Table Schema match the fields in the data source. The default (`exact`) matches the Data Package v1 behaviour, but other values (e.g. `subset`, `superset`) allow to define fewer or more fields and match on field names. This new property extends and makes explicit the `schema_sync` option in Frictionless Framework ([#39](https://github.com/frictionlessdata/datapackage/pull/39)).
-
-##### New property `uniqueKeys`
-
-[`uniqueKeys`](../../specifications/table-schema/#uniquekeys) allows to specify which fields are required to have unique logical values. It is an alternative to `field.contraints.unique` and is modelled after the corresponding SQL feature ([#30](https://github.com/frictionlessdata/datapackage/pull/30)).
-
 ##### New field property `missingValues`
 
 [`missingValues`](../../specifications/table-schema/#missingvalues) allows to specify missing values per field, and overwrites `missingValues` specified at a resource level ([#24](https://github.com/frictionlessdata/datapackage/pull/24)).
+
+#### Field Types
+
+##### Updated field type `integer`
+
+[`groupChar`](../../specifications/table-schema/#integer) can now be used for the `integer` field type. It was already available for `number` ([#6](https://github.com/frictionlessdata/datapackage/pull/6)).
+
+##### New field type `list`
+
+[`list`](../../specifications/table-schema/#list) allows to specify fields containing collections of primary values separated by a delimiter (e.g. `value1,value2`) ([#38](https://github.com/frictionlessdata/datapackage/pull/38)).
 
 ##### Updated field type `datetime`
 
@@ -98,25 +110,19 @@ The definition for [`geopoint`](../../specifications/table-schema/#geopoint) now
 
 [`any`](../../specifications/table-schema/#any) is now the default field type and clarifies that the field type should not be inferred if not provided ([#13](https://github.com/frictionlessdata/datapackage/pull/13)).
 
-##### New field type `list`
-
-[`list`](../../specifications/table-schema/#list) allows to specify fields containing collections of primary values separated by a delimiter (e.g. `value1,value2`) ([#38](https://github.com/frictionlessdata/datapackage/pull/38)).
+#### Field Constraints
 
 ##### Updated constraints `minimum` and `maximum`
 
 [`minimum`](../../specifications/table-schema/#minimum) and [`maximum`](../../specifications/table-schema/#maximum) are now extended to support the `duration` field type ([#8](https://github.com/frictionlessdata/datapackage/pull/8)).
 
-##### New constraint `jsonschema`
-
-[`jsonSchema`](../../specifications/table-schema/#jsonschema) can be used for the `object` and `array` field types ([#32](https://github.com/frictionlessdata/datapackage/pull/32)).
-
 ##### New constraints `exclusiveMinimum` and `exclusiveMaximum`
 
 [`exclusiveMinimum`](../../specifications/table-schema/#exclusiveminimum) and [`exclusiveMaximum`](../../specifications/table-schema/#exclusivemaximum) can be used to specify exclusive minimum and maximum values ([#11](https://github.com/frictionlessdata/datapackage/pull/11)).
 
-##### New integer property `groupChar`
+##### New constraint `jsonschema`
 
-[`groupChar`](../../specifications/table-schema/#integer) can now be used for the `integer` field type. It was already available for `number` ([#6](https://github.com/frictionlessdata/datapackage/pull/6)).
+[`jsonSchema`](../../specifications/table-schema/#jsonschema) can be used for the `object` and `array` field types ([#32](https://github.com/frictionlessdata/datapackage/pull/32)).
 
 ## v1.0
 

--- a/content/docs/standard/changelog.md
+++ b/content/docs/standard/changelog.md
@@ -16,45 +16,45 @@ The Data Package (v2) draft release includes a rich set of the specification imp
 
 ### Data Package
 
-##### Updated property `version`
+##### `version` (updated)
 
 [`version`](../../specifications/data-package/#version) is now included in the specification, while in Data Package v1 it was erroneously only part of the documentation ([#3](https://github.com/frictionlessdata/datapackage/pull/3)).
 
-##### Updated property `contributor.title`
+##### `contributor.title` (updated)
 
 [`contributor.title`](../../specifications/data-package/#contributors) is no longer required ([#7](https://github.com/frictionlessdata/datapackage/pull/7)).
 
-##### New properties `contributor.givenName` and `contributor.familyName`
+##### `contributor.givenName` and `contributor.familyName` (new)
 
 [`contributor.givenName`](../../specifications/data-package/#contributors) and [`contributor.familyName`](../../specifications/data-package/#contributors) can be used to specify the given and family name of contributor, if it is a person ([#20](https://github.com/frictionlessdata/datapackage/pull/20)).
 
-##### New property `contributor.roles`
+##### `contributor.roles` (new)
 
 [`contributor.roles`](../../specifications/data-package/#contributors) allows to specify multiple roles per contributor, rather than having to duplicate the contributor. Other changes from the now deprecated `role` are that it recommendeds to follow an established vocabulary and has new suggested values ([#18](https://github.com/frictionlessdata/datapackage/pull/18)).
 
-##### Deprecated property `contributor.role`
+##### `contributor.role` (deprecated)
 
 `contributor.role` has been deprecated in favour of `contributor.roles`, see above ([#18](https://github.com/frictionlessdata/datapackage/pull/18)).
 
-##### Updated property `source.title`
+##### `source.title` (updated)
 
 [`source.title`](../../specifications/data-package/#sources) is no longer required ([#7](https://github.com/frictionlessdata/datapackage/pull/7)).
 
-##### New property `source.version`
+##### `source.version` (new)
 
 [`source.version`](../../specifications/data-package/#sources) allows to specify which version of a source was used ([#10](https://github.com/frictionlessdata/datapackage/pull/10)).
 
 ### Data Resource
 
-##### Updated property `name`
+##### `name` (updated)
 
 [name](../../specifications/data-resource/#name-required) now allows any string. It previously required the name to only consist of lowercase alphanumeric characters plus `.`, `-` and `_`. The property is still required and must be unique among resources ([#27](https://github.com/frictionlessdata/datapackage/pull/27)).
 
-##### Updated property `path`
+##### `path` (updated)
 
 [path](../../specifications/data-resource/#path-or-data-required) now explicitely forbids hidden folders (starting with dot `.`) ([#19](https://github.com/frictionlessdata/datapackage/pull/19)).
 
-##### Updated property `encoding`
+##### `encoding` (updated)
 
 [encoding](../../specifications/data-resource/#encoding)'s definition has been updated to support binary formats like Parquet ([#15](https://github.com/frictionlessdata/datapackage/pull/15)).
 
@@ -66,61 +66,63 @@ The Data Package (v2) draft release includes a rich set of the specification imp
 
 #### Schema
 
-##### New property `fieldsMatch`
+##### `fieldsMatch` (new)
 
 [fieldsMatch](../../specifications/table-schema/#fieldsmatch) allows to specify how fields in a Table Schema match the fields in the data source. The default (`exact`) matches the Data Package v1 behaviour, but other values (e.g. `subset`, `superset`) allow to define fewer or more fields and match on field names. This new property extends and makes explicit the `schema_sync` option in Frictionless Framework ([#39](https://github.com/frictionlessdata/datapackage/pull/39)).
 
-##### Updated property `primaryKey`
+##### `primaryKey` (updated)
 
 [`primaryKey`](../../specifications/table-schema/#primarykey) should now always be an array of strings, not a string ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
 
-##### New property `uniqueKeys`
+##### `uniqueKeys` (new)
 
 [`uniqueKeys`](../../specifications/table-schema/#uniquekeys) allows to specify which fields are required to have unique logical values. It is an alternative to `field.contraints.unique` and is modelled after the corresponding SQL feature ([#30](https://github.com/frictionlessdata/datapackage/pull/30)).
 
-##### Updated property `foreignKeys`
+##### `foreignKeys` (updated)
 
 [`foreignKeys`](../../specifications/table-schema/#foreignkeys) should now always be an array of strings, not a string ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
 
 `foreignKeys.reference.resource` can now be omitted for self-referencing foreign keys. Previously it required setting resource to an empty string ([#29](https://github.com/frictionlessdata/datapackage/pull/29)).
 
-##### New field property `missingValues`
+#### Fields
+
+##### `missingValues` (new)
 
 [`missingValues`](../../specifications/table-schema/#missingvalues) allows to specify missing values per field, and overwrites `missingValues` specified at a resource level ([#24](https://github.com/frictionlessdata/datapackage/pull/24)).
 
 #### Field Types
 
-##### Updated field type `integer`
+##### `integer` (updated)
 
-[`groupChar`](../../specifications/table-schema/#integer) can now be used for the `integer` field type. It was already available for `number` ([#6](https://github.com/frictionlessdata/datapackage/pull/6)).
+[`integer`](../../specifications/table-schema/#integer) now has a `groupChar` property. It was already available for `number` ([#6](https://github.com/frictionlessdata/datapackage/pull/6)).
 
-##### New field type `list`
+##### `list` (new)
 
 [`list`](../../specifications/table-schema/#list) allows to specify fields containing collections of primary values separated by a delimiter (e.g. `value1,value2`) ([#38](https://github.com/frictionlessdata/datapackage/pull/38)).
 
-##### Updated field type `datetime`
+##### `datetime` (updated)
 
-The default `format` for [`datetime`](../../specifications/table-schema/#datetime) is now extended to allow optional milliseconds and timezone parts ([#23](https://github.com/frictionlessdata/datapackage/pull/23)).
+[`datetime`](../../specifications/table-schema/#datetime)'s default `format` is now extended to allow optional milliseconds and timezone parts ([#23](https://github.com/frictionlessdata/datapackage/pull/23)).
 
-##### Updated field type `geopoint`
+##### `geopoint` (updated)
 
-The definition for [`geopoint`](../../specifications/table-schema/#geopoint) now clarifies that floating point numbers can be used for coordinate definitions ([#14](https://github.com/frictionlessdata/datapackage/pull/14)).
+[`geopoint`](../../specifications/table-schema/#geopoint)'s definition now clarifies that floating point numbers can be used for coordinate definitions ([#14](https://github.com/frictionlessdata/datapackage/pull/14)).
 
-##### Updated field type `any`
+##### `any` (updated)
 
 [`any`](../../specifications/table-schema/#any) is now the default field type and clarifies that the field type should not be inferred if not provided ([#13](https://github.com/frictionlessdata/datapackage/pull/13)).
 
 #### Field Constraints
 
-##### Updated constraints `minimum` and `maximum`
+##### `minimum` and `maximum` (updated)
 
 [`minimum`](../../specifications/table-schema/#minimum) and [`maximum`](../../specifications/table-schema/#maximum) are now extended to support the `duration` field type ([#8](https://github.com/frictionlessdata/datapackage/pull/8)).
 
-##### New constraints `exclusiveMinimum` and `exclusiveMaximum`
+##### `exclusiveMinimum` and `exclusiveMaximum` (new)
 
 [`exclusiveMinimum`](../../specifications/table-schema/#exclusiveminimum) and [`exclusiveMaximum`](../../specifications/table-schema/#exclusivemaximum) can be used to specify exclusive minimum and maximum values ([#11](https://github.com/frictionlessdata/datapackage/pull/11)).
 
-##### New constraint `jsonschema`
+##### `jsonschema` (new)
 
 [`jsonSchema`](../../specifications/table-schema/#jsonschema) can be used for the `object` and `array` field types ([#32](https://github.com/frictionlessdata/datapackage/pull/32)).
 

--- a/content/docs/standard/changelog.md
+++ b/content/docs/standard/changelog.md
@@ -14,39 +14,35 @@ This document includes all meaningful changes made to the **specifications** con
 
 The Data Package (v2) draft release includes a rich set of the specification improvements accepted by the Data Package Working Group during the active phase of the Data Package (v2) work.
 
-### Specifications
-
-##### Added `source.version` property
-
-This change adds a new property to make possible of providing information about source version. Please read more about [`source.version`](../../specifications/data-package/#sources) property.
-
-> [Pull Request -- #10](https://github.com/frictionlessdata/datapackage/pull/10)
-
-##### Made `contributor/source.title` not required
-
-This change allows omitting `title` property for the `contributor` and `source` objects making it more flexible for data producers.
-
-> [Pull Request -- #7](https://github.com/frictionlessdata/datapackage/pull/7)
-
 ### Data Package
 
-##### Added `contributor.given/familyName`
+##### Updated property `version`
 
-This change adds two new properties to the `contributor` object: `givenName` and `familyName`. Please read more about [`package.contributors`](../../specifications/data-package/#contributors) property.
+[`version`](../../specifications/data-package/#version) is now included in the specification, while in Data Package v1 it was erroneously only part of the documentation ([#3](https://github.com/frictionlessdata/datapackage/pull/3)).
 
-> [Pull Request -- #20](https://github.com/frictionlessdata/datapackage/pull/20)
+##### Updated property `contributor.title`
 
-##### Added `contributor.roles` property
+[`contributor.title`](../../specifications/data-package/#contributors) is no longer required ([#7](https://github.com/frictionlessdata/datapackage/pull/7)).
 
-This change adds a new `contributors.roles` property that replaces `contributor.role`. Please read more about [`package.contributors`](../../specifications/data-package/#contributors) property.
+##### Deprecated property `contributor.role`
 
-> [Pull Request -- #18](https://github.com/frictionlessdata/datapackage/pull/18)
+`contributor.role` has been deprecated in favour of `contributor.roles`, see further ([#18](https://github.com/frictionlessdata/datapackage/pull/18)).
 
-##### Fixed `version` property in Data Package profile
+##### Updated property `source.title`
 
-This change adds omitted `version` property to the Data Package profiles.
+[`source.title`](../../specifications/data-package/#sources) is no longer required ([#7](https://github.com/frictionlessdata/datapackage/pull/7)).
 
-> [Pull Request -- #3](https://github.com/frictionlessdata/datapackage/pull/3)
+##### New properties `contributor.givenName` and `contributor.familyName`
+
+[`contributor.givenName`](../../specifications/data-package/#contributors) and [`contributor.familyName`](../../specifications/data-package/#contributors) can be used to specify the given and family name of contributor, if it is a person ([#20](https://github.com/frictionlessdata/datapackage/pull/20)).
+
+##### New property `contributor.roles`
+
+[`contributor.roles`](../../specifications/data-package/#contributors) allows to specify multiple roles per contributor, rather than having to duplicate the contributor. Other changes from the now deprecated `role` are that it recommendeds to follow an established vocabulary and has new suggested values ([#18](https://github.com/frictionlessdata/datapackage/pull/18)).
+
+##### New property `source.version`
+
+[`source.version`](../../specifications/data-package/#sources) allows to specify which version of a source was used ([#10](https://github.com/frictionlessdata/datapackage/pull/10)).
 
 ### Data Resource
 

--- a/content/docs/standard/changelog.md
+++ b/content/docs/standard/changelog.md
@@ -16,13 +16,13 @@ The Data Package (v2) draft release includes a rich set of the specification imp
 
 ### Specifications
 
-#### Added `source.version` property
+##### Added `source.version` property
 
 This change adds a new property to make possible of providing information about source version. Please read more about [`source.version`](../../specifications/data-package/#sources) property.
 
 > [Pull Request -- #10](https://github.com/frictionlessdata/datapackage/pull/10)
 
-#### Made `contributor/source.title` not required
+##### Made `contributor/source.title` not required
 
 This change allows omitting `title` property for the `contributor` and `source` objects making it more flexible for data producers.
 
@@ -30,19 +30,19 @@ This change allows omitting `title` property for the `contributor` and `source` 
 
 ### Data Package
 
-#### Added `contributor.given/familyName`
+##### Added `contributor.given/familyName`
 
 This change adds two new properties to the `contributor` object: `givenName` and `familyName`. Please read more about [`package.contributors`](../../specifications/data-package/#contributors) property.
 
 > [Pull Request -- #20](https://github.com/frictionlessdata/datapackage/pull/20)
 
-#### Added `contributor.roles` property
+##### Added `contributor.roles` property
 
 This change adds a new `contributors.roles` property that replaces `contributor.role`. Please read more about [`package.contributors`](../../specifications/data-package/#contributors) property.
 
 > [Pull Request -- #18](https://github.com/frictionlessdata/datapackage/pull/18)
 
-#### Fixed `version` property in Data Package profile
+##### Fixed `version` property in Data Package profile
 
 This change adds omitted `version` property to the Data Package profiles.
 
@@ -50,19 +50,19 @@ This change adds omitted `version` property to the Data Package profiles.
 
 ### Data Resource
 
-#### Relaxed `resource.name` rules but keep it required and unique
+##### Updated property `name`
 
 This change relaxes requirements to `resource.name` allowing it to be any string. This property still needs to present and be unique among resources. Please read more about [`resource.name`](../../specifications/data-resource/#name-required) property.
 
 > [Pull Request -- #27](https://github.com/frictionlessdata/datapackage/pull/27)
+##### Updated property `encoding`
 
-#### Clarified `resource.encoding` property
 
 This change updates the `resource.encoding` property definition to properly support binary file formats like Parquet. Please read more about [`resource.encoding`](../../specifications/data-resource/#encoding) property.
+##### Updated property `path`
 
 > [Pull Request -- #15](https://github.com/frictionlessdata/datapackage/pull/15)
 
-#### Forbade hidden folders in paths
 
 This change fixes definition in the Data Resource specification to explicitly forbid hidden folders.
 
@@ -70,65 +70,63 @@ This change fixes definition in the Data Resource specification to explicitly fo
 
 ### Table Dialect
 
-#### First version of the specification
-
 This change adds a new specification Table Dialect that superseeds and extends the CSV Dialect specification to work with other formats like JSON or Excel. Please refer to the [Table Dialect](../../specifications/table-dialect) specification.
 
 > [Pull Request -- #41](https://github.com/frictionlessdata/datapackage/pull/41)
 
 ### Table Schema
 
-#### Updated property `primaryKey`
+##### Updated property `primaryKey`
 
 [`primaryKey`](../../specifications/table-schema/#primarykey) should now always be an array of strings, not a string. ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
 
-#### Updated property `foreignKeys`
+##### Updated property `foreignKeys`
 
 [`foreignKeys`](../../specifications/table-schema/#foreignkeys) should now always be an array of strings, not a string ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
 
 `foreignKey.resource.reference` can now be omitted for self-referencing foreign keys. Previously it required setting resource to an empty string ([#29](https://github.com/frictionlessdata/datapackage/pull/29).
 
-#### New property `fieldsMatch`
+##### New property `fieldsMatch`
 
 [fieldsMatch](../../specifications/table-schema/#fieldsmatch) clarifies the default field matching behaviour between Table Schema and data source fields (i.e. all fields are defined and in the same order) and adds new modes for matching fields ([#39](https://github.com/frictionlessdata/datapackage/pull/39)).
 
-#### New property `uniqueKeys`
+##### New property `uniqueKeys`
 
 [`uniqueKeys`](../../specifications/table-schema/#uniquekeys) allows to specify which fields are required to have unique logical values. It is an alternative to the `field.contraints.unique` property and is modelled after the corresponding SQL feature ([#30](https://github.com/frictionlessdata/datapackage/pull/30)).
 
-#### New field property `missingValues`
+##### New field property `missingValues`
 
 [`missingValues`](../../specifications/table-schema/#missingvalues) allows to specify missing values per field, and overwrites `missingValues` specifified at a resource level ([#24](https://github.com/frictionlessdata/datapackage/pull/24)).
 
-#### Updated field type `datetime`
+##### Updated field type `datetime`
 
 The default `format` for [`datetime`](../../specifications/table-schema/#datetime) is now extended to allow optional milliseconds and timezone parts ([#23](https://github.com/frictionlessdata/datapackage/pull/23)).
 
-#### Updated field type `geopoint`
+##### Updated field type `geopoint`
 
 The definition for [`geopoint`](../../specifications/table-schema/#geopoint) now clarifies that floating point numbers can be used for coordinate definitions ([#14](https://github.com/frictionlessdata/datapackage/pull/14)).
 
-#### Updated field type `any`
+##### Updated field type `any`
 
 [`any`](../../specifications/table-schema/#any) is now the default field type and ensures that the field type is not inferred if not provided ([#13](https://github.com/frictionlessdata/datapackage/pull/13)).
 
-#### New field type `list`
+##### New field type `list`
 
 [`list`](../../specifications/table-schema/#list) allows to specify fields containing collections of primary values, separated by a delimiter (e.g. `value1,value`) ([#38](https://github.com/frictionlessdata/datapackage/pull/38)).
 
-#### Updated constraints `minimum` and `maximum`
+##### Updated constraints `minimum` and `maximum`
 
 [`minimum`](../../specifications/table-schema/#minimum) and [`maximum`](../../specifications/table-schema/#maximum) are now extended to support the `duration` field type ([#8](https://github.com/frictionlessdata/datapackage/pull/8).
 
-#### New constraint `jsonschema`
+##### New constraint `jsonschema`
 
 [`jsonSchema`](../../specifications/table-schema/#jsonschema) can be used for the `object` and `array` field types ([#32](https://github.com/frictionlessdata/datapackage/pull/32)).
 
-#### New constraints `exclusiveMinimum` and `exclusiveMaximum`
+##### New constraints `exclusiveMinimum` and `exclusiveMaximum`
 
 [`exclusiveMinimum`](../../specifications/table-schema/#exclusiveminimum) and [`exclusiveMaximum`](../../specifications/table-schema/#exclusivemaximum) can be used to specify exclusive minimum and maximum contraints ([#11](https://github.com/frictionlessdata/datapackage/pull/11)).
 
-#### New integer property `groupChar`
+##### New integer property `groupChar`
 
 [`groupChar`](../../specifications/table-schema/#integer) can now be used for the `integer` field type. It was already available for `number` ([#6](https://github.com/frictionlessdata/datapackage/pull/6)).
 

--- a/content/docs/standard/changelog.md
+++ b/content/docs/standard/changelog.md
@@ -78,25 +78,25 @@ This change adds a new specification Table Dialect that superseeds and extends t
 
 ##### Updated property `primaryKey`
 
-[`primaryKey`](../../specifications/table-schema/#primarykey) should now always be an array of strings, not a string. ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
+[`primaryKey`](../../specifications/table-schema/#primarykey) should now always be an array of strings, not a string ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
 
 ##### Updated property `foreignKeys`
 
 [`foreignKeys`](../../specifications/table-schema/#foreignkeys) should now always be an array of strings, not a string ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
 
-`foreignKey.resource.reference` can now be omitted for self-referencing foreign keys. Previously it required setting resource to an empty string ([#29](https://github.com/frictionlessdata/datapackage/pull/29).
+`foreignKeys.reference.resource` can now be omitted for self-referencing foreign keys. Previously it required setting resource to an empty string ([#29](https://github.com/frictionlessdata/datapackage/pull/29)).
 
 ##### New property `fieldsMatch`
 
-[fieldsMatch](../../specifications/table-schema/#fieldsmatch) clarifies the default field matching behaviour between Table Schema and data source fields (i.e. all fields are defined and in the same order) and adds new modes for matching fields ([#39](https://github.com/frictionlessdata/datapackage/pull/39)).
+[fieldsMatch](../../specifications/table-schema/#fieldsmatch) allows to specify how fields in a Table Schema match the fields in the data source. The default (`exact`) matches the Data Package v1 behaviour, but other values (e.g. `subset`, `superset`) allow to define fewer or more fields and match on field names. This new property extends and makes explicit the `schema_sync` option in Frictionless Framework ([#39](https://github.com/frictionlessdata/datapackage/pull/39)).
 
 ##### New property `uniqueKeys`
 
-[`uniqueKeys`](../../specifications/table-schema/#uniquekeys) allows to specify which fields are required to have unique logical values. It is an alternative to the `field.contraints.unique` property and is modelled after the corresponding SQL feature ([#30](https://github.com/frictionlessdata/datapackage/pull/30)).
+[`uniqueKeys`](../../specifications/table-schema/#uniquekeys) allows to specify which fields are required to have unique logical values. It is an alternative to `field.contraints.unique` and is modelled after the corresponding SQL feature ([#30](https://github.com/frictionlessdata/datapackage/pull/30)).
 
 ##### New field property `missingValues`
 
-[`missingValues`](../../specifications/table-schema/#missingvalues) allows to specify missing values per field, and overwrites `missingValues` specifified at a resource level ([#24](https://github.com/frictionlessdata/datapackage/pull/24)).
+[`missingValues`](../../specifications/table-schema/#missingvalues) allows to specify missing values per field, and overwrites `missingValues` specified at a resource level ([#24](https://github.com/frictionlessdata/datapackage/pull/24)).
 
 ##### Updated field type `datetime`
 
@@ -108,15 +108,15 @@ The definition for [`geopoint`](../../specifications/table-schema/#geopoint) now
 
 ##### Updated field type `any`
 
-[`any`](../../specifications/table-schema/#any) is now the default field type and ensures that the field type is not inferred if not provided ([#13](https://github.com/frictionlessdata/datapackage/pull/13)).
+[`any`](../../specifications/table-schema/#any) is now the default field type and clarifies that the field type should not be inferred if not provided ([#13](https://github.com/frictionlessdata/datapackage/pull/13)).
 
 ##### New field type `list`
 
-[`list`](../../specifications/table-schema/#list) allows to specify fields containing collections of primary values, separated by a delimiter (e.g. `value1,value`) ([#38](https://github.com/frictionlessdata/datapackage/pull/38)).
+[`list`](../../specifications/table-schema/#list) allows to specify fields containing collections of primary values separated by a delimiter (e.g. `value1,value2`) ([#38](https://github.com/frictionlessdata/datapackage/pull/38)).
 
 ##### Updated constraints `minimum` and `maximum`
 
-[`minimum`](../../specifications/table-schema/#minimum) and [`maximum`](../../specifications/table-schema/#maximum) are now extended to support the `duration` field type ([#8](https://github.com/frictionlessdata/datapackage/pull/8).
+[`minimum`](../../specifications/table-schema/#minimum) and [`maximum`](../../specifications/table-schema/#maximum) are now extended to support the `duration` field type ([#8](https://github.com/frictionlessdata/datapackage/pull/8)).
 
 ##### New constraint `jsonschema`
 
@@ -124,7 +124,7 @@ The definition for [`geopoint`](../../specifications/table-schema/#geopoint) now
 
 ##### New constraints `exclusiveMinimum` and `exclusiveMaximum`
 
-[`exclusiveMinimum`](../../specifications/table-schema/#exclusiveminimum) and [`exclusiveMaximum`](../../specifications/table-schema/#exclusivemaximum) can be used to specify exclusive minimum and maximum contraints ([#11](https://github.com/frictionlessdata/datapackage/pull/11)).
+[`exclusiveMinimum`](../../specifications/table-schema/#exclusiveminimum) and [`exclusiveMaximum`](../../specifications/table-schema/#exclusivemaximum) can be used to specify exclusive minimum and maximum values ([#11](https://github.com/frictionlessdata/datapackage/pull/11)).
 
 ##### New integer property `groupChar`
 

--- a/content/docs/standard/changelog.md
+++ b/content/docs/standard/changelog.md
@@ -80,83 +80,21 @@ This change adds a new specification Table Dialect that superseeds and extends t
 
 #### Table Schema
 
-##### Added `schema.fieldsMatch` property
+- New [`fieldsMatch`](../../specifications/table-schema/#fieldsmatch) property: clarifies the default field matching behaviour between Table Schema and data source fields (i.e. all fields are defined and in the same order) and adds new modes for matching fields ([#39](https://github.com/frictionlessdata/datapackage/pull/39)).
+- New [`uniqueKeys`](../../specifications/table-schema/#uniquekeys) property: allows to specify which fields are required to have unique logical values. It is an alternative to the `field.contraints.unique` property and is modelled after the corresponding SQL feature ([#30](https://github.com/frictionlessdata/datapackage/pull/30)).
+- Updated [`primaryKey`](../../specifications/table-schema/#primarykey): should now always be an array ([#28](https://github.com/frictionlessdata/datapackage/pull/28)).
+- Updated [`foreignKeys`](../../specifications/table-schema/#foreignkeys): should now always be an array ([#28](https://github.com/frictionlessdata/datapackage/pull/28)). `foreignKey.resource.reference` can now be omitted in case of self-referencing. Previously it required setting resource to an empty string ([#29](https://github.com/frictionlessdata/datapackage/pull/29).
+- New [`missingValues`](../../specifications/table-schema/#missingvalues) field property: allows to specify missing values per field (in addition to `missingValues` at a resource level) ([#24](https://github.com/frictionlessdata/datapackage/pull/24)).
+- Updated [`datetime`](../../specifications/table-schema/#datetime) field type: the default `format` for `datetime` is now extended to allow optional milliseconds and timezone parts ([#23](https://github.com/frictionlessdata/datapackage/pull/23)).
+- Updated [`geopoint`](../../specifications/table-schema/#geopoint) field type: the definition now clarifies that floating point numbers can be used for coordinate definitions ([#14](https://github.com/frictionlessdata/datapackage/pull/14)).
+- Updated [`any`](../../specifications/table-schema/#any) field type: `any` is now the default field type and ensures that the field type is not inferred if not provided ([#13](https://github.com/frictionlessdata/datapackage/pull/13)).
+- New [`list`](../../specifications/table-schema/#list) field type: allows to specify collections of primary values collections, separated by a delimiter (e.g. `value1,value`) ([#38](https://github.com/frictionlessdata/datapackage/pull/38)).
+- Updated [`minimum`](../../specifications/table-schema/#minimum) and [`maximum`](../../specifications/table-schema/#maximum) constraints: these constraints now support the `duration` field type ([#8](https://github.com/frictionlessdata/datapackage/pull/8).
+- New [`jsonSchema`](../../specifications/table-schema/#jsonschema) field constraint: can be used for `object` and `array` fields ([#32](https://github.com/frictionlessdata/datapackage/pull/32)).
+- New [`exclusiveMinimum`](../../specifications/table-schema/#exclusiveminimum) and [`exclusiveMaximum`](../../specifications/table-schema/#exclusivemaximum) field contraints ([#11](https://github.com/frictionlessdata/datapackage/pull/11)).
+- New [`groupChar`](../../specifications/table-schema/#integer) integer property: supports group characters for integers. It was already available for numbers ([#6](https://github.com/frictionlessdata/datapackage/pull/6)).
 
-This change clarifies the default field matching behaviour and adds new modes for matching data source and Table Schema fields. Please read more about [`schema.fieldsMatch`](../../specifications/table-schema/#fieldsmatch) property.
-
-> [Pull Request -- #39](https://github.com/frictionlessdata/datapackage/pull/39)
-
-##### Made `any` be a default field type
-
-This change makes field type to be `any` by default and ensures that the field type is not inferred if not provided. Please read more about [`any`](../../specifications/table-schema/#any) type.
-
-> [Pull Request -- #13](https://github.com/frictionlessdata/datapackage/pull/13)
-
-##### Added `uniqueKeys` property
-
-This change adds `uniqueKeys` property directly modelled after corresponding SQL feature. Please read more about [`schema.uniqueKeys`](../../specifications/table-schema/#uniquekeys) property.
-
-> [Pull Request -- #30](https://github.com/frictionlessdata/datapackage/pull/30)
-
-##### Added `field.missingValues`
-
-This change adds a property that allows to specify missing values individually per field. Please read more about [`field.missingValues`](../../specifications/table-schema/#missingvalues) property.
-
-> [Pull Request -- #24](https://github.com/frictionlessdata/datapackage/pull/24)
-
-##### Added `list` field type
-
-This change adds a new field type `list` for typed collections, lexically delimiter-based. Please read more about [`list`](../../specifications/table-schema/#list) type.
-
-> [Pull Request -- #38](https://github.com/frictionlessdata/datapackage/pull/38)
-
-##### Added `jsonSchema` constraint to object and array fields
-
-This change adds a new constraint for the `object` and `array` fields. Please read more about [`constraints.jsonSchema`](../../specifications/table-schema/#jsonschema) constraint.
-
-> [Pull Request -- #32](https://github.com/frictionlessdata/datapackage/pull/32)
-
-##### Support `groupChar` for integer field type
-
-This change adds support for providing integers with group chars. Please read more about [`field.groupChar`](../../specifications/table-schema/#integer) property.
-
-> [Pull Request -- #6](https://github.com/frictionlessdata/datapackage/pull/6)
-
-##### Extended `datetime` default format
-
-This change extends `default` format definition for the `datetime` field type allowing to provide optional milliseconds and timezone parts.
-
-> [Pull Request -- #23](https://github.com/frictionlessdata/datapackage/pull/23)
-
-##### Supported exclusive constraints
-
-This change adds new `exclusiveMinimum` and `exclusiveMaximum` constraints to the Table Schema specification.
-
-> [Pull Request -- #11](https://github.com/frictionlessdata/datapackage/pull/11)
-
-##### Simplified self-referencing in foreign keys
-
-This change allows omitting `foreignKey.resource.reference` in case of self-referencing. Previously it required setting resource to an empty string.
-
-> [Pull Request -- #29](https://github.com/frictionlessdata/datapackage/pull/29)
-
-##### Discouraged usage of unnecessary union types
-
-This change discourages usage of mixed types for `schema.primaryKeys` and `schema.foreignKeys.fields` properties.
-
-> [Pull Request -- #28](https://github.com/frictionlessdata/datapackage/pull/28)
-
-##### Clarified that `geopoint` is number-based
-
-This changes clarifies that `geopoint` field type can use floating point numbers for coordinate definitions.
-
-> [Pull Request -- #14](https://github.com/frictionlessdata/datapackage/pull/14)
-
-##### Fixed duration constraint
-
-This change fixes `minimum` and `maximum` constraint for the `duration` field type.
-
-> [Pull Request -- #8](https://github.com/frictionlessdata/datapackage/pull/8)
+> [Pull Request -- 
 
 ## v1.0
 

--- a/content/docs/standard/changelog.md
+++ b/content/docs/standard/changelog.md
@@ -52,27 +52,19 @@ This change adds omitted `version` property to the Data Package profiles.
 
 ##### Updated property `name`
 
-This change relaxes requirements to `resource.name` allowing it to be any string. This property still needs to present and be unique among resources. Please read more about [`resource.name`](../../specifications/data-resource/#name-required) property.
+[name](../../specifications/data-resource/#name-required) now allows any string. It previously required the name to only consist of lowercase alphanumeric characters plus `.`, `-` and `_`. The property is still required and must be unique among resources ([#27](https://github.com/frictionlessdata/datapackage/pull/27)).
 
-> [Pull Request -- #27](https://github.com/frictionlessdata/datapackage/pull/27)
 ##### Updated property `encoding`
 
+[encoding](../../specifications/data-resource/#encoding)'s definition has been updated to support binary formats like Parquet ([#15](https://github.com/frictionlessdata/datapackage/pull/15)).
 
-This change updates the `resource.encoding` property definition to properly support binary file formats like Parquet. Please read more about [`resource.encoding`](../../specifications/data-resource/#encoding) property.
 ##### Updated property `path`
 
-> [Pull Request -- #15](https://github.com/frictionlessdata/datapackage/pull/15)
-
-
-This change fixes definition in the Data Resource specification to explicitly forbid hidden folders.
-
-> [Pull Request -- #19](https://github.com/frictionlessdata/datapackage/pull/19)
+[path](../../specifications/data-resource/#path-or-data-required) now explicitely forbids hidden folders (starting with dot `.`) ([#19](https://github.com/frictionlessdata/datapackage/pull/19)).
 
 ### Table Dialect
 
-This change adds a new specification Table Dialect that superseeds and extends the CSV Dialect specification to work with other formats like JSON or Excel. Please refer to the [Table Dialect](../../specifications/table-dialect) specification.
-
-> [Pull Request -- #41](https://github.com/frictionlessdata/datapackage/pull/41)
+[Table Dialect](../../specifications/table-dialect) is a new specification that superseeds and extends the CSV Dialect specification. It support other formats like JSON or Excel ([#41](https://github.com/frictionlessdata/datapackage/pull/41)).
 
 ### Table Schema
 


### PR DESCRIPTION
Build upon https://github.com/frictionlessdata/datapackage/pull/59, intended to be merged into https://github.com/frictionlessdata/datapackage/pull/60

- Reorganize CHANGELOG (shorter titles and descriptions)
- Make a minor correction to the language section
- Update author name
- Correct definition for `given/familyName`