### PR TITLE
Allow `package.created` not include a timezone part

### DIFF
--- a/content/docs/specifications/data-package.md
+++ b/content/docs/specifications/data-package.md
@@ -202,13 +202,13 @@ A version string identifying the version of the package. It `SHOULD` conform to 
 
 The datetime on which this was created.
 
-Note: semantics may vary between publishers -- for some this is the datetime the data was created, for others the datetime the package was created.
+Semantics may vary between publishers -- for some this is the datetime the data was created, for others the datetime the package was created.
 
-The datetime `MUST` conform to the string formats for datetime as described in [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6). Example:
+The datetime `MUST` conform to the string formats for datetime as described in [XML Schema](https://www.w3.org/TR/xmlschema-2/#dateTime) containing required date and time parts, followed by optional milliseconds and timezone parts, for example, `2024-01-26T15:00:00` or `2024-01-26T15:00:00.300-05:00`:
 
 ```json
 {
-  "created": "1985-04-12T23:20:50.52Z"
+  "created": "1985-04-12T23:20:50.52"
 }
 ```
 

--- a/profiles/source/dictionary/common.yaml
+++ b/profiles/source/dictionary/common.yaml
@@ -124,10 +124,8 @@ tabularData:
 created:
   title: Created
   description: The datetime on which this descriptor was created.
-  context: The datetime must conform to the string formats for datetime as described
-    in [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6)
   type: string
-  format: date-time
+  pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})?$"
   examples:
     - |
       {

--- a/profiles/target/2.0/datapackage.json
+++ b/profiles/target/2.0/datapackage.json
@@ -78,9 +78,8 @@
       "propertyOrder": 70,
       "title": "Created",
       "description": "The datetime on which this descriptor was created.",
-      "context": "The datetime must conform to the string formats for datetime as described in [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6)",
       "type": "string",
-      "format": "date-time",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})?$",
       "examples": [
         "{\n  \"created\": \"1985-04-12T23:20:50.52Z\"\n}\n"
       ]


### PR DESCRIPTION
# Rationale

Currently, `package.created` is required to be [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6), i.e. JSONSchema's `date-time` format for strings. It requires to contain a timezone.

For many systems and workflows, the timezone is not applicable. For example, here is a [CKAN extension](https://github.com/frictionlessdata/ckanext-datapackage) data package endpoint output:

![created](https://github.com/frictionlessdata/datapackage/assets/557395/33b0ff20-3385-4c13-ac78-b0179cc12d7d)

A similar problem is actual for Zenodo `datapackage.json` exporter and others.